### PR TITLE
Sync 'checked' property in example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ new Vue({
 ```
 
 ```html
-<mdl-checkbox :checked.sync='check'>Checkbox</mdl-checkbox>
+<mdl-checkbox :checked.sync='checked'>Checkbox</mdl-checkbox>
 ```
 
 For more detailed usage about non es6 environments, check the


### PR DESCRIPTION
The property on the vue instance is `checked` but the template was referencing `check`.