### PR TITLE
Fix readonly and disabled attr on textarea

### DIFF
--- a/src/textfield.vue
+++ b/src/textfield.vue
@@ -5,7 +5,7 @@
       i.material-icons {{expandable}}
   div(v-bind:class='{"mdl-textfield__expandable-holder": expandable}')
     slot(v-if='textarea' name='textarea')
-      textarea.mdl-textfield__input(type='text' v-model='value' v-bind:required='required' v-bind:id.once='id' v-bind:rows='rows' v-bind:maxlength='maxlength')
+      textarea.mdl-textfield__input(type='text' v-model='value' v-bind:required='required' v-bind:id.once='id' v-bind:rows='rows' v-bind:disabled='disabled' v-bind:readonly='readonly' v-bind:maxlength='maxlength')
     slot(v-else name='input')
       input.mdl-textfield__input(v-bind:type='type' v-model='value' v-bind:id.once='id' v-bind:pattern='pattern' v-bind:disabled='disabled' v-bind:required='required' v-bind:readonly='readonly' v-bind:maxlength='maxlength')
     slot(name='label')

--- a/test/components/Textfield.vue
+++ b/test/components/Textfield.vue
@@ -51,6 +51,11 @@ div
   <mdl-textfield :value.sync='requiredValue' id='required-textarea' floating-label='Required' required textarea></mdl-textfield>
   mdl-textfield#maxlength-input(:value.sync='requiredValue', :maxlength='maxlength', floating-label="Maxlength")
   mdl-textfield#maxlength-textarea(:value.sync='requiredValue', :maxlength='maxlength', floating-label="Maxlength" textarea)
+  mdl-textfield#disabled-input(:value.sync='text', disabled, floating-label="Disabled")
+  mdl-textfield#disabled-textarea(:value.sync='text', disabled, floating-label="Disabled" textarea)
+  mdl-textfield#readonly-input(:value.sync='text', readonly, floating-label="Disabled")
+  mdl-textfield#readonly-textarea(:value.sync='text', readonly, floating-label="Disabled" textarea)
+
 </template>
 
 <script lang="babel">

--- a/test/unit/specs/Textfield.spec.js
+++ b/test/unit/specs/Textfield.spec.js
@@ -245,4 +245,16 @@ describe('Textfield', () => {
     vm.$('#maxlength-input').should.have.attr('maxlength', '10')
     vm.$('#maxlength-textarea').should.have.attr('maxlength', '10')
   })
+
+  it('binds a disabled attr', () => {
+    vm.$('#expandable').should.not.have.attr('disabled')
+    vm.$('#disabled-input').should.have.attr('disabled')
+    vm.$('#disabled-textarea').should.have.attr('disabled')
+  })
+
+  it('binds a readonly attr', () => {
+    vm.$('#expandable').should.not.have.attr('readonly')
+    vm.$('#readonly-input').should.have.attr('readonly')
+    vm.$('#readonly-textarea').should.have.attr('readonly')
+  })
 })


### PR DESCRIPTION
The two attrs, readonly and disabled, were not bind onto textarea textfields. This PR fixed this issue and added related tests.