### PR TITLE
Initial work to support VueJS 2.0

### DIFF
--- a/doc/src/VmdlDoc.vue
+++ b/doc/src/VmdlDoc.vue
@@ -85,7 +85,7 @@ p a
 </style>
 
 <template lang="jade">
-.mdl-layout.mdl-js-layout.mdl-layout--fixed-drawer.mdl-layout--fixed-header(v-el='menu')
+.mdl-layout.mdl-js-layout.mdl-layout--fixed-drawer.mdl-layout--fixed-header(ref='menu')
   header.mdl-layout__header
     .mdl-layout__header-row
       span.header-title
@@ -93,7 +93,7 @@ p a
         | Vue MDL
       .mdl-layout-spacer
       mdl-textfield.mdl-textfield--align-right(id='search' expandable='search' v-bind:value.sync='filter')
-  .mdl-layout__drawer(v-el:drawer)
+  .mdl-layout__drawer(ref='drawer')
     menu-entry(v-for='menu in items', :menu='menu')
     span.mdl-layout-title.mdl-layout-title--icon
       i.material-icons link
@@ -107,7 +107,7 @@ p a
 </template>
 
 <script>
-/* global docsearch*/
+/* global docsearch */
 import menuEntry from './utils/menu-entry.vue'
 
 export default {

--- a/doc/src/VmdlDoc.vue
+++ b/doc/src/VmdlDoc.vue
@@ -92,7 +92,7 @@ p a
         img.mdl-layout__header-logo(src='http://vuejs.org/images/logo.png')
         | Vue MDL
       .mdl-layout-spacer
-      mdl-textfield.mdl-textfield--align-right(id='search' expandable='search' v-bind:value.sync='filter')
+      mdl-textfield.mdl-textfield--align-right(id='search' expandable='search' v-model='filter')
   .mdl-layout__drawer(ref='drawer')
     menu-entry(v-for='menu in items', :menu='menu')
     span.mdl-layout-title.mdl-layout-title--icon

--- a/doc/src/main.js
+++ b/doc/src/main.js
@@ -17,36 +17,38 @@ Vue.use(VueMdl)
 Vue.use(VueRouter)
 
 Vue.component('title-link', require('./utils/title-link.vue'))
-Vue.directive('hljs', require('./utils/hljs').default)
-Vue.mixin({
-  ready () {
-    hljs.initHighlighting.called = false
-    hljs.initHighlighting()
-    document.querySelector('#app main').scrollTop = 0
-  }
-})
-
-let routerMap = {}
-context.keys().forEach(function (comp) {
-  let name = path.basename(comp, '.vue')
-  Vue.component(name, context(comp))
-  routerMap[`/${name}`] = {
-    component: context(comp)
-  }
-})
-
-let router = new VueRouter({
-})
-router.map(routerMap)
-
-router.redirect({
-  '/': '/installation'
-})
-
-Vue.config.debug = process.env.NODE_ENV !== 'production'
-router.start(VmdlDoc, '#app')
 
 hljs.registerLanguage('css', require('highlight.js/lib/languages/css'))
 hljs.registerLanguage('xml', require('highlight.js/lib/languages/xml'))
 hljs.registerLanguage('javascript', require('highlight.js/lib/languages/javascript'))
 
+Vue.directive('hljs', require('./utils/hljs').default)
+Vue.mixin({
+  mounted () {
+    hljs.initHighlighting.called = false
+    hljs.initHighlighting()
+    document.querySelector('main').scrollTop = 0
+  }
+})
+
+let routerMap = [
+  { path: '/', redirect: '/installation' }
+]
+context.keys().forEach(function (comp) {
+  let name = path.basename(comp, '.vue')
+  Vue.component(name, context(comp))
+  routerMap.push({ path: `/${name}`, component: context(comp) })
+})
+
+let router = new VueRouter({
+  routes: routerMap
+})
+
+Vue.config.debug = process.env.NODE_ENV !== 'production'
+new Vue({
+  router,
+  components: { VmdlDoc },
+  render: function (h) {
+    return h('vmdl-doc')
+  }
+}).$mount('#app')

--- a/doc/src/main.js
+++ b/doc/src/main.js
@@ -31,18 +31,17 @@ Vue.mixin({
   }
 })
 
-let routerMap = [
+let routes = [
   { path: '/', redirect: '/installation' }
 ]
+
 context.keys().forEach(function (comp) {
   let name = path.basename(comp, '.vue')
   Vue.component(name, context(comp))
-  routerMap.push({ path: `/${name}`, component: context(comp) })
+  routes.push({ path: `/${name}`, component: context(comp) })
 })
 
-let router = new VueRouter({
-  routes: routerMap
-})
+let router = new VueRouter({ routes })
 
 Vue.config.debug = process.env.NODE_ENV !== 'production'
 new Vue({

--- a/doc/src/partials/badges.vue
+++ b/doc/src/partials/badges.vue
@@ -24,8 +24,8 @@ i.material-icons.mdl-badge
       span(v-mdl-badge.no-background='value') Inbox
       i.material-icons(v-mdl-badge.overlap='text') account_box
     .flex.start.wrap
-      mdl-textfield(:value.sync='value', label='Badge Number', floating-label)
-      mdl-textfield(:value.sync='text', label='Badge Text', floating-label)
+      mdl-textfield(v-model='value', label='Badge Number', floating-label)
+      mdl-textfield(v-model='text', label='Badge Text', floating-label)
 
     p Pass the text you want to the directive:
     pre
@@ -56,8 +56,8 @@ i.material-icons.mdl-badge
       span(v-mdl-badge='num', :hide-badge='zero') Inbox
       span(v-mdl-badge.number='num', :hide-badge='hide') Inbox
     .flex.start.wrap
-      mdl-slider(min=0 max=15 v-bind:value.sync='num')
-      mdl-checkbox(:checked.sync='hide') Hide
+      mdl-slider(min=0 max=15 v-model='num')
+      mdl-checkbox(v-model='hide') Hide
 
     pre
       code.html

--- a/doc/src/partials/buttons.vue
+++ b/doc/src/partials/buttons.vue
@@ -10,7 +10,7 @@
         code ripple-effect
     .flex.start.wrap
       mdl-button.space Button
-      mdl-button.space(mdl-ripple-effect) Ripple Effect
+      mdl-button.space(v-mdl-ripple-effect) Ripple Effect
       mdl-button.space(disabled) Disabled
       mdl-button.space(icon)
         i.material-icons star

--- a/doc/src/partials/buttons.vue
+++ b/doc/src/partials/buttons.vue
@@ -5,19 +5,19 @@
 .section
   title-link Buttons
   .section__content
-    p The button component allows to easily toggle classes. It supports the 
-      a(v-link.literal='/ripple-effect')
+    p The button component allows to easily toggle classes. It supports the
+      router-link(to="/ripple-effect")
         code ripple-effect
     .flex.start.wrap
       mdl-button.space Button
-      mdl-button.space(v-mdl-ripple-effect) Ripple Effect
+      mdl-button.space(mdl-ripple-effect) Ripple Effect
       mdl-button.space(disabled) Disabled
       mdl-button.space(icon)
         i.material-icons star
     pre
       code.html
         p= '<mdl-button>Button</mdl-button>'
-        p= '<mdl-button v-mdl-ripple-effect>Ripple Effect</mdl-button>'
+        p= '<mdl-button mdl-ripple-effect>Ripple Effect</mdl-button>'
         p= '<mdl-button disabled>Disabled</mdl-button>'
         p= '<mdl-button icon>'
         p= '  <i class="material-icons">star</i>'
@@ -31,17 +31,17 @@
         i.material-icons(v-if='iconText') {{iconText}}
         span(v-else) {{text}}
     .flex.center.wrap
-      mdl-checkbox.reset-width.space(:checked.sync='colored') Colored
-      mdl-checkbox.reset-width.space(:checked.sync='raised') Raised
-      mdl-checkbox.reset-width.space(:checked.sync='disabled') Disabled
-      mdl-checkbox.reset-width.space(:checked.sync='icon') Icon
-      mdl-checkbox.reset-width.space(:checked.sync='accent') Accent
-      mdl-checkbox.reset-width.space(:checked.sync='primary') Primary
-      mdl-checkbox.reset-width.space(:checked.sync='miniFab') Mini Fab
-      mdl-checkbox.reset-width.space(:checked.sync='fab') Fab
+      mdl-checkbox.reset-width.space(v-model='colored') Colored
+      mdl-checkbox.reset-width.space(v-model='raised') Raised
+      mdl-checkbox.reset-width.space(v-model='disabled') Disabled
+      mdl-checkbox.reset-width.space(v-model='icon') Icon
+      mdl-checkbox.reset-width.space(v-model='accent') Accent
+      mdl-checkbox.reset-width.space(v-model='primary') Primary
+      mdl-checkbox.reset-width.space(v-model='miniFab') Mini Fab
+      mdl-checkbox.reset-width.space(v-model='fab') Fab
     .flex.start.wrap
-      mdl-textfield.space(:value.sync='text', label='Text', floating-label)
-      mdl-textfield.space(:value.sync='iconText', label='Icon', floating-label)
+      mdl-textfield.space(v-model='text', label='Text', floating-label)
+      mdl-textfield.space(v-model='iconText', label='Icon', floating-label)
     p Result:
     pre
       code.html(v-hljs='playgroundHtml')

--- a/doc/src/partials/cards.vue
+++ b/doc/src/partials/cards.vue
@@ -41,8 +41,8 @@
     .flex.start.wrap
       mdl-card.reset-height.white-space(:title='cardTitle', :supporting-text='supportingText', actions, actions-text='View updates')
     .flex.start.wrap
-      mdl-textfield(:value.sync='cardTitle', floating-label='Card Title')
-      mdl-textfield(textarea, :value.sync='supportingText', floating-label='Supporting Text')
+      mdl-textfield(v-model='cardTitle', floating-label='Card Title')
+      mdl-textfield(textarea, v-model='supportingText', floating-label='Supporting Text')
 
     p Pass the text you want to the directive:
     pre

--- a/doc/src/partials/checkboxes.vue
+++ b/doc/src/partials/checkboxes.vue
@@ -6,43 +6,43 @@
   title-link Checkboxes
   .section__content
     p The checkbox supports the
-      a(v-link.literal='/ripple-effect')  ripple effect
+      router-link(to="/ripple-effect")  ripple effect
     .flex.start.wrap
-      mdl-checkbox(:checked.sync='checked') Checkbox
-      mdl-checkbox.mdl-js-ripple-effect(:checked.sync='checked') Ripple Effect
-      mdl-checkbox(:checked.sync='checked', disabled) Disabled
+      mdl-checkbox(v-model='checked') Checkbox
+      mdl-checkbox.mdl-js-ripple-effect(v-model='checked') Ripple Effect
+      mdl-checkbox(v-model='checked', disabled) Disabled
     pre
       code.html
-        p= '<mdl-checkbox :checked.sync="checked">Checkbox</mdl-checkbox>'
-        p= '<mdl-checkbox :checked.sync="checked" class="mdl-js-ripple-effect">Ripple Effect</mdl-checkbox>'
-        p= '<mdl-checkbox :checked.sync="checked" disabled>Disabled</mdl-checkbox>'
+        p= '<mdl-checkbox v-model="checked">Checkbox</mdl-checkbox>'
+        p= '<mdl-checkbox v-model="checked" class="mdl-js-ripple-effect">Ripple Effect</mdl-checkbox>'
+        p= '<mdl-checkbox v-model="checked" disabled>Disabled</mdl-checkbox>'
 
     p You can pass an 
       code id
       |  to the component to access through the form element
     pre
       code.html
-        p= '<mdl-checkbox id="Subscribe" :checked.sync="subscribe">Subscribe</mdl-checkbox>'
+        p= '<mdl-checkbox id="Subscribe" v-model="subscribe">Subscribe</mdl-checkbox>'
 
     p Instead of using multiple booleans for a group of checkboxes, you can directly pass the same array to multiple checkboxes. If you do this you also need to specify the 
      code value
      |  prop
 
     .flex.start.wrap
-      mdl-checkbox(:checked.sync='checks', value='one') One
-      mdl-checkbox(:checked.sync='checks', value='two') Two
-      mdl-checkbox(:checked.sync='checks', value='three') Three
-      mdl-checkbox(:checked.sync='checks', value='four') Four
-      mdl-checkbox(:checked.sync='checks', value='five') Five
-      p Arrays content: {{checks | json}}
+      mdl-checkbox(v-model='checks', selected-value='one') One
+      mdl-checkbox(v-model='checks', selected-value='two') Two
+      mdl-checkbox(v-model='checks', selected-value='three') Three
+      mdl-checkbox(v-model='checks', selected-value='four') Four
+      mdl-checkbox(v-model='checks', selected-value='five') Five
+      p Arrays content: {{checks}}
 
     pre
       code.html
-        p= '<mdl-checkbox :checked.sync="checks" value="one">One</mdl-checkbox>'
-        p= '<mdl-checkbox :checked.sync="checks" value="two">Two</mdl-checkbox>'
-        p= '<mdl-checkbox :checked.sync="checks" value="three">Three</mdl-checkbox>'
-        p= '<mdl-checkbox :checked.sync="checks" value="four">Four</mdl-checkbox>'
-        p= '<mdl-checkbox :checked.sync="checks" value="five">Five</mdl-checkbox>'
+        p= '<mdl-checkbox v-model="checks" selected-value="one">One</mdl-checkbox>'
+        p= '<mdl-checkbox v-model="checks" selected-value="two">Two</mdl-checkbox>'
+        p= '<mdl-checkbox v-model="checks" selected-value="three">Three</mdl-checkbox>'
+        p= '<mdl-checkbox v-model="checks" selected-value="four">Four</mdl-checkbox>'
+        p= '<mdl-checkbox v-model="checks" selected-value="five">Five</mdl-checkbox>'
 
     h5 Prop List
     table.mdl-data-table.mdl-js-data-table
@@ -61,9 +61,9 @@
           td.mdl-data-table__cell--non-numeric
         tr
           td.mdl-data-table__cell--non-numeric
-            code checked
+            code value
           td.mdl-data-table__cell--non-numeric Control whether the checkbox is checked or not
-          td.mdl-data-table__cell--non-numeric You must use a two way binding. You can either use a boolean or an array
+          td.mdl-data-table__cell--non-numeric Typically used with 'v-model' binding. You can either use a boolean or an array
         tr
           td.mdl-data-table__cell--non-numeric
             code id
@@ -71,7 +71,7 @@
           td.mdl-data-table__cell--non-numeric
         tr
           td.mdl-data-table__cell--non-numeric
-            code value
+            code selected-value
           td.mdl-data-table__cell--non-numeric Defines the value of the checkbox. Useful when passing an array to the 
             code checked
             |  prop

--- a/doc/src/partials/dialogs.vue
+++ b/doc/src/partials/dialogs.vue
@@ -7,15 +7,15 @@
   .section__content
     p The dialog component allows for verification of user actions, simple data input, and alerts to provide extra information to users. To display dialogs, use events.
 
-    div(v-transfer-dom)
-      mdl-dialog(v-ref:info-message title='Hi there')
+    div
+      mdl-dialog(ref='infoMessage' title='Hi there')
         p Hello. This is an information message. You can click outside or in the close button to close it.
     .flex.center.wrap
-      mdl-button(fab, primary, v-on:click='$refs.infoMessage.open')
+      mdl-button(fab, primary, v-on:click.native='$refs.infoMessage.open')
         i.material-icons power_settings_new
     pre
       code.html
-        p= '<mdl-dialog v-ref:info-message title="Hi there">'
+        p= '<mdl-dialog ref="infoMessage" title="Hi there">'
         p= '  <p>Hello. This is an information message. You can click outside or in the close button to close it.</p>'
         p= '</mdl-dialog>'
 
@@ -32,15 +32,15 @@
 
     pre
       code.html
-        p= '<div v-transfer-dom>'
-        p= '  <mdl-dialog v-ref:info-message title="Hi there">'
+        p= '<div>'
+        p= '  <mdl-dialog ref="infoMessage" title="Hi there">'
         p= '    <p>Hello. This is an information message. You can click outside or in the close button to close it.</p>'
         p= '  </mdl-dialog>'
         p= '</div>'
 
     p The example above use this technique to prevent the menu from overlapping.
 
-    p The dialgo component emits an&nbsp;
+    p The dialog component emits an&nbsp;
       code open
       |  event when it opens as well as a&nbsp;
       code close
@@ -49,7 +49,7 @@
 
     pre
       code.html
-        p= '<mdl-dialog @close="closeCallback" v-ref:info-message title="Hi there">'
+        p= '<mdl-dialog @close="closeCallback" ref="infoMessage" title="Hi there">'
         p= '  <p>Hello. This is an information message. You can click outside or in the close button to close it.</p>'
         p= '</mdl-dialog>'
 
@@ -64,26 +64,26 @@
       code actions
       |  slot:
 
-    div(v-transfer-dom)
-      mdl-dialog(v-ref:multiple full-width title='Hi there')
+    div
+      mdl-dialog(ref='multiple' full-width title='Hi there')
         p Hello.
         p Number is {{ number }}
         p Increase the number or decrease without closing this modal
         template(slot="actions")
-          mdl-button(primary, v-on:click='number++') Increase
-          mdl-button(primary, v-on:click='number--') Decrease
-          mdl-button(v-on:click='$refs.multiple.close') Close
+          mdl-button(primary, v-on:click.native='number++') Increase
+          mdl-button(primary, v-on:click.native='number--') Decrease
+          mdl-button(v-on:click.native='$refs.multiple.close') Close
     .flex.center.wrap
-      mdl-button(fab, primary, v-on:click='$refs.multiple.open')
+      mdl-button(fab, primary, v-on:click.native='$refs.multiple.open')
         i.material-icons power_settings_new
     pre
       code.html
-        p= '<mdl-dialog v-ref:multiple full-width title="Hi there">'
+        p= '<mdl-dialog ref="multiple" full-width title="Hi there">'
         p= '  <p>Hello</p>'
         p= '  <template slot="actions">'
-        p= '    <mdl-button primary @click="number++">Increase</mdl-button>'
-        p= '    <mdl-button primary @click="number--">Decrease</mdl-button>'
-        p= '    <mdl-button @click="$refs.multiple.close">Close</mdl-button>'
+        p= '    <mdl-button primary @click.native="number++">Increase</mdl-button>'
+        p= '    <mdl-button primary @click.native="number--">Decrease</mdl-button>'
+        p= '    <mdl-button @click.native="$refs.multiple.close">Close</mdl-button>'
         p= '  </template>'
         p= '</mdl-dialog>'
 

--- a/doc/src/partials/icon-toggles.vue
+++ b/doc/src/partials/icon-toggles.vue
@@ -6,42 +6,42 @@
   title-link Icon Toggles
   .section__content
     p The icon-toggle component works the same way as the
-      a(v-link.literal='/checkboxes')  checkbox component
+      router-link(to="/checkboxes")  checkbox component
       |. It also supports the
-      a(v-link.literal='/ripple-effect')  ripple effect
+      router-link(to="/ripple-effect")  ripple effect
     .flex.start.wrap
-      mdl-icon-toggle(:checked.sync='bold', icon='format_bold')
-      mdl-icon-toggle.mdl-js-ripple-effect(:checked.sync='italic', icon='format_italic')
-      mdl-icon-toggle(:checked.sync='underline', icon='format_underlined', disabled)
+      mdl-icon-toggle(v-model='bold', icon='format_bold')
+      mdl-icon-toggle.mdl-js-ripple-effect(v-model='italic', icon='format_italic')
+      mdl-icon-toggle(v-model='underline', icon='format_underlined', disabled)
     pre
       code.html
-        p= '<mdl-icon-toggle :checked.sync="checked"  icon="format_bold"></mdl-icon-toggle>'
-        p= '<mdl-icon-toggle :checked.sync="checked" icon="format_italic" class="mdl-js-ripple-effect"></mdl-icon-toggle>'
-        p= '<mdl-icon-toggle :checked.sync="checked" icon="format_underlined" disabled></mdl-icon-toggle>'
+        p= '<mdl-icon-toggle v-model="checked"  icon="format_bold"></mdl-icon-toggle>'
+        p= '<mdl-icon-toggle v-model="checked" icon="format_italic" class="mdl-js-ripple-effect"></mdl-icon-toggle>'
+        p= '<mdl-icon-toggle v-model="checked" icon="format_underlined" disabled></mdl-icon-toggle>'
 
     p You can pass an 
       code id
       |  to the component to access through the form element
     pre
       code.html
-        p= '<mdl-icon-toggle id="Subscribe" :checked.sync="subscribe">Subscribe</mdl-icon-toggle>'
+        p= '<mdl-icon-toggle id="Subscribe" v-model="subscribe">Subscribe</mdl-icon-toggle>'
 
     p Instead of using multiple booleans for a group of checkboxes, you can directly pass the same array to multiple checkboxes. If you do this you also need to specify the 
      code value
      |  prop
 
     .flex.start.wrap
-      mdl-icon-toggle(:checked.sync='styles', icon='format_bold', value='bold')
-      mdl-icon-toggle(:checked.sync='styles', icon='format_italic', value='italic')
-      mdl-icon-toggle(:checked.sync='styles', icon='format_underlined', value='underlined')
+      mdl-icon-toggle(v-model='styles', icon='format_bold', selected-value='bold')
+      mdl-icon-toggle(v-model='styles', icon='format_italic', selected-value='italic')
+      mdl-icon-toggle(v-model='styles', icon='format_underlined', selected-value='underlined')
     .flex.start.wrap
-      p Arrays content: {{styles | json}}
+      p Arrays content: {{styles}}
 
     pre
       code.html
-        p= '<mdl-icon-toggle :checked.sync="styles" icon="format_bold" value="bold"></mdl-icon-toggle>'
-        p= '<mdl-icon-toggle :checked.sync="styles" icon="format_italic" value="italic"></mdl-icon-toggle>'
-        p= '<mdl-icon-toggle :checked.sync="styles" icon="format_underlined" value="underlined"></mdl-icon-toggle>'
+        p= '<mdl-icon-toggle v-model="styles" icon="format_bold" selected-value="bold"></mdl-icon-toggle>'
+        p= '<mdl-icon-toggle v-model="styles" icon="format_italic" selected-value="italic"></mdl-icon-toggle>'
+        p= '<mdl-icon-toggle v-model="styles" icon="format_underlined" selected-value="underlined"></mdl-icon-toggle>'
 
     h5 Prop List
     table.mdl-data-table.mdl-js-data-table
@@ -65,9 +65,9 @@
           td.mdl-data-table__cell--non-numeric
         tr
           td.mdl-data-table__cell--non-numeric
-            code checked
+            code value
           td.mdl-data-table__cell--non-numeric Control whether the icon toggle is checked or not
-          td.mdl-data-table__cell--non-numeric You must use a two way binding. You can either use a boolean or an array
+          td.mdl-data-table__cell--non-numeric Typicaly used with 'v-model'. You can either use a boolean or an array
         tr
           td.mdl-data-table__cell--non-numeric
             code id
@@ -75,7 +75,7 @@
           td.mdl-data-table__cell--non-numeric
         tr
           td.mdl-data-table__cell--non-numeric
-            code value
+            code selected-value
           td.mdl-data-table__cell--non-numeric Defines the value of the toggle. Useful when passing an array to the 
             code checked
             |  prop

--- a/doc/src/partials/radio-buttons.vue
+++ b/doc/src/partials/radio-buttons.vue
@@ -6,22 +6,22 @@
   title-link Radio Buttons
   .section__content
     p The radio button supports the
-      a(v-link.literal='/ripple-effect')  ripple effect
+      router-link(to="/ripple-effect")  ripple effect
     .flex.start.wrap
-      mdl-radio(:checked.sync='checked', value='option 1') Option 1
+      mdl-radio(v-model='checked', selected-value='option 1') Option 1
     .flex.start.wrap
-      mdl-radio.mdl-js-ripple-effect(:checked.sync='checked', value='option 2') Option 2
+      mdl-radio.mdl-js-ripple-effect(v-model='checked', selected-value='option 2') Option 2
     .flex.start.wrap
-      mdl-radio(:checked.sync='checked', value='option 3') Option 3
+      mdl-radio(v-model='checked', selected-value='option 3') Option 3
     .flex.start.wrap
-      mdl-radio(:checked.sync='checked', disabled, value='option 4') Option 4
+      mdl-radio(v-model='checked', disabled, selected-value='option 4') Option 4
     p Option selected: {{checked}}
     pre
       code.html
-        p= '<mdl-radio :checked.sync="check" value="option 1">Option 1</mdl-radio>'
-        p= '<mdl-radio :checked.sync="check" class="mdl-js-ripple-effect" value="option 2">Option 2</mdl-radio>'
-        p= '<mdl-radio :checked.sync="check" value="option 3">Option 3</mdl-radio>'
-        p= '<mdl-radio :checked.sync="check" value="option 4" disabled>Option 4</mdl-radio>'
+        p= '<mdl-radio v-model="check" selected-value="option 1">Option 1</mdl-radio>'
+        p= '<mdl-radio v-model="check" class="mdl-js-ripple-effect" selected-value="option 2">Option 2</mdl-radio>'
+        p= '<mdl-radio v-model="check" selected-value="option 3">Option 3</mdl-radio>'
+        p= '<mdl-radio v-model="check" selected-value="option 4" disabled>Option 4</mdl-radio>'
 
     p You can pass an 
       code id
@@ -30,7 +30,7 @@
       |  to the component to access through the form element
     pre
       code.html
-        p= '<mdl-radio name="subscription-pro" id="subscription-pro" :checked.sync="subscription" value="pro">Pro Subscription</mdl-radio>'
+        p= '<mdl-radio name="subscription-pro" id="subscription-pro" v-model="subscription" selected-value="pro">Pro Subscription</mdl-radio>'
 
     h5 Prop List
     table.mdl-data-table.mdl-js-data-table
@@ -49,9 +49,9 @@
           td.mdl-data-table__cell--non-numeric
         tr
           td.mdl-data-table__cell--non-numeric
-            code checked
+            code value
           td.mdl-data-table__cell--non-numeric Variable to assign when the radio button is checked
-          td.mdl-data-table__cell--non-numeric You must use a two way binding
+          td.mdl-data-table__cell--non-numeric Typically used with 'v-model'.
         tr
           td.mdl-data-table__cell--non-numeric
             code name
@@ -64,7 +64,7 @@
           td.mdl-data-table__cell--non-numeric
         tr
           td.mdl-data-table__cell--non-numeric
-            code value
+            code selected-value
           td.mdl-data-table__cell--non-numeric Defines the value of the radio button
           td.mdl-data-table__cell--non-numeric This prop is required
     br

--- a/doc/src/partials/ripple-effect.vue
+++ b/doc/src/partials/ripple-effect.vue
@@ -15,15 +15,15 @@
         li Icon Toggles
         li Switches
     .flex.start.wrap
-      mdl-radio.mdl-js-ripple-effect(:checked.sync='radio', value='radio') Radio
+      mdl-radio.mdl-js-ripple-effect(v-model='radio', selected-value='radio') Radio
     .flex.start.wrap
       mdl-button.mdl-js-ripple-effect(raised colored) Button
     .flex.start.wrap
-      mdl-checkbox.reset-width.mdl-js-ripple-effect(:checked.sync='check') Checkbox
+      mdl-checkbox.reset-width.mdl-js-ripple-effect(v-model='check') Checkbox
     .flex.start.wrap
-      mdl-icon-toggle.mdl-js-ripple-effect(:checked.sync='check', icon='format_bold')
+      mdl-icon-toggle.mdl-js-ripple-effect(v-model='check', icon='format_bold')
     .flex.start.wrap
-      mdl-switch.reset-width.mdl-js-ripple-effect(:checked.sync='check') Switch
+      mdl-switch.reset-width.mdl-js-ripple-effect(v-model='check') Switch
 
     p At the moment, the 
       code v-mdl-ripple-effect

--- a/doc/src/partials/selects.vue
+++ b/doc/src/partials/selects.vue
@@ -12,12 +12,12 @@
       |  html element.
 
     .flex.center.wrap
-      mdl-select#country-select(label='Country', :value.sync='country', :options='countriesArray')
+      mdl-select#country-select(label='Country', v-model='country', :options='countriesArray')
     .flex.center.wrap
       p Selected country is {{country}}
     pre
       code.html
-        p= '<mdl-select label="Country" id="contry-select" :value.sync="country" :options="countriesArray"></mdl-select>'
+        p= '<mdl-select label="Country" id="contry-select" v-model="country" :options="countriesArray"></mdl-select>'
       code.javascript.
         new Vue({
           data: {
@@ -34,12 +34,12 @@
       |  properties.
 
     .flex.center.wrap
-      mdl-select#country-select-2(label='Country', :value.sync='countryVal', :options='countries')
+      mdl-select#country-select-2(label='Country', v-model='countryVal', :options='countries')
     .flex.center.wrap
       p Selected country is {{countryVal}}
     pre
       code.html
-        p= '<mdl-select label="Country" id="contry-select" :value.sync="country" :options="countries"></mdl-select>'
+        p= '<mdl-select label="Country" id="contry-select" v-model="country" :options="countries"></mdl-select>'
       code.javascript.
         new Vue({
           data: {

--- a/doc/src/partials/snackbars.vue
+++ b/doc/src/partials/snackbars.vue
@@ -17,11 +17,11 @@
     .flex.center.wrap
       mdl-snackbar(display-on='mailSent')
     .flex.center.wrap
-      mdl-button(raised, colored, @click='$broadcast("mailSent", { message: "Message Sent" })') Show
+      mdl-button(raised, colored, @click.native="$root.$emit('mailSent', { message: 'Message Sent' })") Show
     pre
       code.html
         p= '<mdl-snackbar display-on="mailSent"></mdl-snackbar>'
-        p= '<mdl-button raised colored @click="$broadcast(\'mailSent\', { message: \'Message Sent\' })">Show</mdl-button>'
+        p= '<mdl-button raised colored @click.native="$root.$emit(\'mailSent\', { message: \'Message Sent\' })">Show</mdl-button>'
 
     p The object passed when broadcasting the event 
       code mailSent
@@ -33,12 +33,12 @@
     .flex.center.wrap
       mdl-snackbar(display-on='colorChanged')
     .flex.center.wrap
-      mdl-button(:style='buttonStyle', raised, @click='changeColor') Change color
+      mdl-button(:style='buttonStyle', raised, @click.native='changeColor') Change color
 
     pre
       code.html
         p= '<mdl-snackbar display-on="colorChanged"></mdl-snackbar>'
-        p= '<mdl-button raised :style="buttonStyle" @click="changeColor">Change color</mdl-button>'
+        p= '<mdl-button raised :style="buttonStyle" @click.native="changeColor">Change color</mdl-button>'
       code.javascript.
         new Vue({
           data: {
@@ -58,7 +58,7 @@
           methods: {
             changeColor () {
               this.color = `#${Math.floor(Math.random() * 0xFFFFFF).toString(16)}`
-              this.$broadcast('colorChanged', {
+              this.$root.$emit('colorChanged', {
                 message: 'Color changed',
                 actionHandler: (event) => {
                   this.color = null
@@ -96,7 +96,7 @@ export default {
   methods: {
     changeColor () {
       this.color = `#${Math.floor(Math.random() * 0xFFFFFF).toString(16)}`
-      this.$broadcast('colorChanged', {
+      this.$root.$emit('colorChanged', {
         message: 'Color changed',
         actionHandler: (event) => {
           this.color = null

--- a/doc/src/partials/spinners.vue
+++ b/doc/src/partials/spinners.vue
@@ -19,7 +19,7 @@
       |  prop to
       code  false
     .flex.start.wrap
-      mdl-checkbox(:checked.sync='active') Active
+      mdl-checkbox(v-model='active') Active
     .flex.center.wrap
       mdl-spinner(:active='active')
     pre

--- a/doc/src/partials/switches.vue
+++ b/doc/src/partials/switches.vue
@@ -6,43 +6,43 @@
   title-link Switches
   .section__content
     p Switches support the
-      a(v-link.literal='/ripple-effect')  ripple effect
+      router-link(to="/ripple-effect")  ripple effect
     .flex.start.wrap
-      mdl-switch(:checked.sync='checked') Switch
-      mdl-switch.mdl-js-ripple-effect(:checked.sync='checked') Ripple Effect
-      mdl-switch(:checked.sync='checked', disabled) Disabled
+      mdl-switch(v-model='checked') Switch
+      mdl-switch.mdl-js-ripple-effect(v-model='checked') Ripple Effect
+      mdl-switch(v-model='checked', disabled) Disabled
     pre
       code.html
-        p= '<mdl-switch :checked.sync="checked">Switch</mdl-switch>'
-        p= '<mdl-switch :checked.sync="checked" class="mdl-js-ripple-effect">Ripple Effect</mdl-switch>'
-        p= '<mdl-switch :checked.sync="checked" disabled>Disabled</mdl-switch>'
+        p= '<mdl-switch v-model="checked">Switch</mdl-switch>'
+        p= '<mdl-switch v-model="checked" class="mdl-js-ripple-effect">Ripple Effect</mdl-switch>'
+        p= '<mdl-switch v-model="checked" disabled>Disabled</mdl-switch>'
 
     p You can pass an 
       code id
       |  to the component to access through the form element
     pre
       code.html
-        p= '<mdl-switch id="Subscribe" :checked.sync="subscribe">Subscribe</mdl-switch>'
+        p= '<mdl-switch id="Subscribe" v-model="subscribe">Subscribe</mdl-switch>'
 
     p Instead of using multiple booleans for a group of checkboxes, you can directly pass the same array to multiple checkboxes. If you do this you also need to specify the 
      code value
      |  prop
 
     .flex.start.wrap
-      mdl-switch(:checked.sync='checks', value='one') One
-      mdl-switch(:checked.sync='checks', value='two') Two
-      mdl-switch(:checked.sync='checks', value='three') Three
-      mdl-switch(:checked.sync='checks', value='four') Four
-      mdl-switch(:checked.sync='checks', value='five') Five
-      p Arrays content: {{checks | json}}
+      mdl-switch(v-model='checks', selected-value='one') One
+      mdl-switch(v-model='checks', selected-value='two') Two
+      mdl-switch(v-model='checks', selected-value='three') Three
+      mdl-switch(v-model='checks', selected-value='four') Four
+      mdl-switch(v-model='checks', selected-value='five') Five
+      p Arrays content: {{checks}}
 
     pre
       code.html
-        p= '<mdl-switch :checked.sync="checks" value="one">One</mdl-switch>'
-        p= '<mdl-switch :checked.sync="checks" value="two">Two</mdl-switch>'
-        p= '<mdl-switch :checked.sync="checks" value="three">Three</mdl-switch>'
-        p= '<mdl-switch :checked.sync="checks" value="four">Four</mdl-switch>'
-        p= '<mdl-switch :checked.sync="checks" value="five">Five</mdl-switch>'
+        p= '<mdl-switch v-model="checks" selected-value="one">One</mdl-switch>'
+        p= '<mdl-switch v-model="checks" selected-value="two">Two</mdl-switch>'
+        p= '<mdl-switch v-model="checks" selected-value="three">Three</mdl-switch>'
+        p= '<mdl-switch v-model="checks" selected-value="four">Four</mdl-switch>'
+        p= '<mdl-switch v-model="checks" selected-value="five">Five</mdl-switch>'
 
     h5 Prop List
     table.mdl-data-table.mdl-js-data-table
@@ -61,9 +61,9 @@
           td.mdl-data-table__cell--non-numeric
         tr
           td.mdl-data-table__cell--non-numeric
-            code checked
+            code value
           td.mdl-data-table__cell--non-numeric Control whether the switch is checked or not
-          td.mdl-data-table__cell--non-numeric You must use a two way binding. You can either use a boolean or an array
+          td.mdl-data-table__cell--non-numeric Typically used with 'v-model'. You can either use a boolean or an array
         tr
           td.mdl-data-table__cell--non-numeric
             code id
@@ -71,7 +71,7 @@
           td.mdl-data-table__cell--non-numeric
         tr
           td.mdl-data-table__cell--non-numeric
-            code value
+            code selected-value
           td.mdl-data-table__cell--non-numeric Defines the value of the switch. Useful when passing an array to the 
             code checked
             |  prop

--- a/doc/src/partials/textfields.vue
+++ b/doc/src/partials/textfields.vue
@@ -17,18 +17,18 @@
     .flex.center.wrap
       p Hello {{name}}
     .flex.start.wrap
-      mdl-textfield.space(label='Name', :value.sync='name')
-      mdl-textfield.space(floating-label='Name', :value.sync='name')
+      mdl-textfield.space(label='Name', v-model='name')
+      mdl-textfield.space(floating-label='Name', v-model='name')
     pre
       code.html
-        p= '<mdl-textfield label="Name" :value.sync="name"></mdl-textfield>'
-        p= '<mdl-textfield floating-label="Name" :value.sync="name"></mdl-textfield>'
+        p= '<mdl-textfield label="Name" v-model="name"></mdl-textfield>'
+        p= '<mdl-textfield floating-label="Name" v-model="name"></mdl-textfield>'
 
     p Use the 
       code textarea
       |  prop to use a textarea instead of an input
     .flex.start.wrap
-      mdl-textfield(floating-label='Textarea', textarea, rows='4', :value.sync='text')
+      mdl-textfield(floating-label='Textarea', textarea, rows='4', v-model='text')
       p {{text}}
     pre
       code.html= '<mdl-textfield floating-label="Name" textarea rows="4"></mdl-textfield>'
@@ -63,13 +63,13 @@
     // .flex.start.wrap
     //   mdl-textfield(:floating-label='float', :label='label', :textarea='textarea', :rows='rows')
     // .flex.start.wrap
-    //   mdl-checkbox.reset-width.space(:checked.sync='float') Floating label
-    //   mdl-checkbox.reset-width.space(:checked.sync='textarea') Textarea
+    //   mdl-checkbox.reset-width.space(v-model='float') Floating label
+    //   mdl-checkbox.reset-width.space(v-model='textarea') Textarea
     // .flex.start.wrap
     //   p Rows: 
-    //   mdl-slider.reset-width.space(:value.sync='rows', min='1', max='20')
+    //   mdl-slider.reset-width.space(v-model='rows', min='1', max='20')
     // .flex.start.wrap
-    //   mdl-textfield.space(:value.sync='label', floating-label='Label')
+    //   mdl-textfield.space(v-model='label', floating-label='Label')
     // p Result:
     // pre
     //   code.html(v-hljs='playgroundHtml')

--- a/doc/src/partials/tooltips.vue
+++ b/doc/src/partials/tooltips.vue
@@ -10,12 +10,12 @@
       code  for
       |  prop to bind to the correct dom element
     .flex.center.wrap
-      mdl-tooltip(for='add-button') Add something!
+      mdl-tooltip(target='add-button') Add something!
       mdl-button#add-button(fab, primary)
         i.material-icons add
     pre
       code.html
-        p= '<mdl-tooltip for="add-button">Add something!</mdl-tooltip>'
+        p= '<mdl-tooltip target="add-button">Add something!</mdl-tooltip>'
         p= '<mdl-button id="add-button" fab primary>'
         p= '  <i class="material-icons">add</i>'
         p= '</mdl-button>'
@@ -25,12 +25,12 @@
       |  prop
 
     .flex.center.wrap
-      mdl-tooltip(large, for='send-button') Let it go!
+      mdl-tooltip(large, target='send-button') Let it go!
       mdl-button#send-button(raised, primary)
         i.material-icons send
     pre
       code.html
-        p= '<mdl-tooltip for="send-button" large>Let it go!</mdl-tooltip>'
+        p= '<mdl-tooltip target="send-button" large>Let it go!</mdl-tooltip>'
         p= '<mdl-button id="send-button" fab primary>'
         p= '  <i class="material-icons">send</i>'
         p= '</mdl-button>'
@@ -38,7 +38,7 @@
     p You can also add html inside the tooltip
 
     .flex.center.wrap
-      mdl-tooltip(large, for='mood-button')
+      mdl-tooltip(large, target='mood-button')
         | Here is some
         strong  custom
         code  html
@@ -48,7 +48,7 @@
         i.material-icons mood
     pre
       code.html
-        p= '<mdl-tooltip for="mood-button">Add something!</mdl-tooltip>'
+        p= '<mdl-tooltip target="mood-button">Add something!</mdl-tooltip>'
         p= '<mdl-button id="mood-button" fab primary>'
         p= '  Here is some <strong>custom</strong> <code>html</code><br/><i class="material-icons">mood</i>'
         p= '</mdl-button>'
@@ -63,7 +63,7 @@
       tbody
         tr
           td.mdl-data-table__cell--non-numeric
-            code  for
+            code  target
           td.mdl-data-table__cell--non-numeric
             code id
             |  of another item. The tooltip is binded to the item with the specified

--- a/doc/src/utils/hljs.js
+++ b/doc/src/utils/hljs.js
@@ -1,12 +1,6 @@
 import hljs from 'highlight.js/lib/highlight'
 
-export default {
-  bind (el, { value }) {
-    el.innerText = value
-    hljs.highlightBlock(el)
-  },
-  update (el, { value }) {
-    el.innerText = value
-    hljs.highlightBlock(el)
-  }
+export default function (el, { value }) {
+  el.innerText = value
+  hljs.highlightBlock(el)
 }

--- a/doc/src/utils/hljs.js
+++ b/doc/src/utils/hljs.js
@@ -1,8 +1,12 @@
 import hljs from 'highlight.js/lib/highlight'
 
 export default {
-  update (value) {
-    this.el.innerText = value
-    hljs.highlightBlock(this.el)
+  bind (el, { value }) {
+    el.innerText = value
+    hljs.highlightBlock(el)
+  },
+  update (el, { value }) {
+    el.innerText = value
+    hljs.highlightBlock(el)
   }
 }

--- a/doc/src/utils/menu-entry.vue
+++ b/doc/src/utils/menu-entry.vue
@@ -1,9 +1,10 @@
 <template lang="jade">
-span.mdl-layout-title.mdl-layout-title--icon
-  i.material-icons {{menu.icon}}
-  span {{menu.name}}
-nav.mdl-navigation(v-for='sub in menu.items')
-  a.mdl-navigation__link(v-link='makeLink(sub)' @click='closeMenu') {{sub}}
+div
+  span.mdl-layout-title.mdl-layout-title--icon
+    i.material-icons {{menu.icon}}
+    span {{menu.name}}
+  nav.mdl-navigation(v-for='sub in menu.items')
+    router-link.mdl-navigation__link(:to='makeLink(sub)' @click.native='closeMenu') {{sub}}
 </template>
 
 <script>
@@ -20,7 +21,7 @@ export default {
       return `/${_.kebabCase(text)}`
     },
     closeMenu () {
-      if (this.$parent.$els.drawer.classList.contains('is-visible')) {
+      if (this.$parent.$refs.drawer.classList.contains('is-visible')) {
         this.$parent.$el.MaterialLayout.drawerToggleHandler_()
       }
     }

--- a/doc/src/utils/title-link.vue
+++ b/doc/src/utils/title-link.vue
@@ -22,11 +22,8 @@ a.title-link
 </style>
 
 <template lang="jade">
-a.title-link(v-link='link', :id.once='id', :class='{"title-link--big": big}')
-  h2(v-if='big')
-    slot
-  h3(v-else)
-    slot
+router-link.title-link(:to='link', :id.once='id', :class="{'title-link--big': big}")
+  slot
 </template>
 
 <script>

--- a/doc/src/utils/title-link.vue
+++ b/doc/src/utils/title-link.vue
@@ -23,7 +23,8 @@ a.title-link
 
 <template lang="jade">
 router-link.title-link(:to='link', :id.once='id', :class="{'title-link--big': big}")
-  slot
+  component(:is='header')
+    slot
 </template>
 
 <script>
@@ -39,6 +40,9 @@ export default {
   computed: {
     link () {
       return '/' + this.id
+    },
+    header () {
+      return this.big ? 'h2' : 'h3'
     }
   },
   ready () {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "author": "posva",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^1.0.26"
+    "vue": "^2.0.0-rc.3"
   },
   "devDependencies": {
     "babel-core": "^6.13.2",
@@ -89,11 +89,11 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^2.3.1",
     "url-loader": "^0.5.7",
-    "vue": "^1.0.26",
-    "vue-hot-reload-api": "^1.2.0",
+    "vue": "^2.0.0-rc.3",
+    "vue-hot-reload-api": "^2.0.6",
     "vue-html-loader": "^1.2.3",
-    "vue-loader": "^8.5.2",
-    "vue-router": "^0.7.13",
+    "vue-loader": "^9.3.2",
+    "vue-router": "^2.0.0-rc.3",
     "vue-style-loader": "^1.0.0",
     "vue-transfer-dom": "^1.1.0",
     "webpack": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "author": "posva",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^2.0.0-rc.3"
+    "vue": "^2.0.0-rc.4"
   },
   "devDependencies": {
     "babel-core": "^6.13.2",
@@ -89,7 +89,7 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^2.3.1",
     "url-loader": "^0.5.7",
-    "vue": "^2.0.0-rc.3",
+    "vue": "^2.0.0-rc.4",
     "vue-hot-reload-api": "^2.0.6",
     "vue-html-loader": "^1.2.3",
     "vue-loader": "^9.3.2",

--- a/src/card.vue
+++ b/src/card.vue
@@ -73,7 +73,6 @@ export default {
   },
   methods: {
     triggerMenuEvent () {
-      console.log('About to emit: ', this.menu)
       this.$emit(this.menu)
     },
     triggerActionsEvent () {

--- a/src/card.vue
+++ b/src/card.vue
@@ -15,11 +15,11 @@
     .mdl-card__actions.mdl-card--border
       mdl-anchor-button.mdl-js-ripple-effect(colored v-if='isActionsURL' v-bind:href='actions'
         v-bind:target='actionsTarget') {{actionsText}}
-      mdl-button.mdl-js-ripple-effect(colored v-else v-on:click='triggerActionsEvent') {{actionsText}}
+      mdl-button.mdl-js-ripple-effect(colored v-else @click.native='triggerActionsEvent') {{actionsText}}
   // TODO some way of creating a menu or action
   slot(name='menu' v-if='menu')
     .mdl-card__menu
-      mdl-button.mdl-js-ripple-effect(icon @click='triggerMenuEvent')
+      mdl-button.mdl-js-ripple-effect(icon @click.native='triggerMenuEvent')
         i.material-icons share
 
 </template>
@@ -48,40 +48,23 @@ export default {
     }
   },
   props: {
-    title: {
-      type: String,
-      default: true
-    },
-    menu: {
-      default: true
-    },
-    actions: {
-      type: String,
-      default: true
-    },
+    title: String,
+    menu: String,
+    actions: String,
     actionsTarget: {
       default: '_self',
       type: String
     },
     actionsText: String,
-    media: {
-      default: true,
-      type: String
-    },
-    subtitle: {
-      default: true,
-      type: String
-    },
-    supportingText: {
-      default: true,
-      type: String
-    }
+    media: String,
+    subtitle: String,
+    supportingText: String
   },
-  compiled () {
+  mounted () {
     slots.forEach((slot, pos) => {
       if (this[slot] === true) {
         let el = this.$el.children[pos]
-        if (!el || !el.attributes.getNamedItem('slot')) {
+        if (!el || !this.$el.attributes.getNamedItem('slot')) {
           this[slot] = ''
         }
       }
@@ -90,10 +73,11 @@ export default {
   },
   methods: {
     triggerMenuEvent () {
-      this.$dispatch(this.menu)
+      console.log('About to emit: ', this.menu)
+      this.$emit(this.menu)
     },
     triggerActionsEvent () {
-      this.$dispatch(this.actions)
+      this.$emit(this.actions)
     }
   },
   components: {

--- a/src/dialog.vue
+++ b/src/dialog.vue
@@ -4,13 +4,12 @@
     .mdl-dialog__title {{title}}
     .mdl-dialog__content
       slot
-    .mdl-dialog__actions(v-bind:class='{ "mdl-dialog__actions--full-width": fullWidth }')
+    .mdl-dialog__actions(v-bind:class="{ 'mdl-dialog__actions--full-width': fullWidth }")
       slot(name='actions')
-        mdl-button.mdl-js-ripple-effect(v-on:click.stop='close') Close
+        mdl-button.mdl-js-ripple-effect(v-on:click.native.stop='close') Close
 </template>
 
 <script>
-import propFill from './mixins/prop-fill'
 import mdlButton from './button.vue'
 
 export default {
@@ -26,10 +25,7 @@ export default {
     title: {
       type: String
     },
-    fullWidth: {
-      fill: true,
-      default: false
-    }
+    fullWidth: Boolean
   },
   methods: {
     open () {
@@ -40,8 +36,7 @@ export default {
       this.show = false
       this.$emit('close')
     }
-  },
-  mixins: [propFill]
+  }
 }
 </script>
 <style>

--- a/src/directives/badge.js
+++ b/src/directives/badge.js
@@ -3,36 +3,28 @@ const checkNumber = function (num) {
   return num > 0
 }
 
-const dataBadgeSetter = function (hide, value) {
-  if (hide) {
-    this.el.removeAttribute('data-badge')
-  } else if (!this.isNumber || checkNumber(value)) {
-    this.el.setAttribute('data-badge', value)
+const updateBadgeValue = function (el, binding) {
+  if (!binding.modifiers.number || checkNumber(binding.value)) {
+    el.setAttribute('data-badge', binding.value)
   } else {
-    this.el.removeAttribute('data-badge')
+    el.removeAttribute('data-badge')
   }
 }
 
 export default {
-  bind () {
-    this.el.classList.add('mdl-badge')
-    if ('overlap' in this.modifiers) {
-      this.el.classList.add('mdl-badge--overlap')
+  bind (el, binding) {
+    el.classList.add('mdl-badge')
+    if ('overlap' in binding.modifiers) {
+      el.classList.add('mdl-badge--overlap')
     }
-    if ('no-background' in this.modifiers) {
-      this.el.classList.add('mdl-badge--no-background')
+    if ('no-background' in binding.modifiers) {
+      el.classList.add('mdl-badge--no-background')
     }
-    this.isNumber = 'number' in this.modifiers
+
+    updateBadgeValue(el, binding)
   },
-  params: ['hide-badge'],
-  paramWatchers: {
-    hideBadge (hide) {
-      dataBadgeSetter.call(this, hide, this.value)
-    }
-  },
-  update (value) {
-    this.value = value
-    dataBadgeSetter.call(this, this.params.hideBadge, value)
+  update (el, binding) {
+    updateBadgeValue(el, binding)
   }
 }
 

--- a/src/directives/mdl.js
+++ b/src/directives/mdl.js
@@ -1,5 +1,5 @@
 export default {
-  bind () {
-    componentHandler.upgradeElements(this.el)
+  bind (el) {
+    componentHandler.upgradeElements(el)
   }
 }

--- a/src/directives/mdl.js
+++ b/src/directives/mdl.js
@@ -1,5 +1,5 @@
 export default {
   bind (el) {
-    componentHandler.upgradeElements(el)
+    componentHandler.upgradeElements(this && this.el || el)
   }
 }

--- a/src/directives/ripple-effect.js
+++ b/src/directives/ripple-effect.js
@@ -1,5 +1,5 @@
 export default {
-  bind () {
-    this.el.classList.add('mdl-js-ripple-effect')
+  bind (el) {
+    el.classList.add('mdl-js-ripple-effect')
   }
 }

--- a/src/menu/menu.vue
+++ b/src/menu/menu.vue
@@ -1,12 +1,12 @@
 <template lang="jade">
-ul.mdl-menu.mdl-js-menu(v-bind:for.once='for')
+ul.mdl-menu.mdl-js-menu(v-bind:for.once='target')
   slot
 </template>
 
 <script>
 export default {
-  props: ['for'],
-  ready () {
+  props: ['target'],
+  mounted () {
     componentHandler.upgradeElement(this.$el, 'MaterialMenu')
   }
   // beforeDestroy () {

--- a/src/menu/menu.vue
+++ b/src/menu/menu.vue
@@ -7,6 +7,7 @@ ul.mdl-menu.mdl-js-menu(v-bind:for.once='target')
 export default {
   props: ['target'],
   mounted () {
+    console.log('Menu: ', this.$el)
     componentHandler.upgradeElement(this.$el, 'MaterialMenu')
   }
   // beforeDestroy () {

--- a/src/mixins/button.js
+++ b/src/mixins/button.js
@@ -1,5 +1,3 @@
-import propFill from './prop-fill'
-
 export default {
   computed: {
     cssClasses () {

--- a/src/mixins/button.js
+++ b/src/mixins/button.js
@@ -15,33 +15,18 @@ export default {
     }
   },
   props: {
-    disabled: {
-      fill: true
-    },
+    disabled: Boolean,
     icon: {
       required: false
     },
-    accent: {
-      fill: true
-    },
-    primary: {
-      fill: true
-    },
-    miniFab: {
-      fill: true
-    },
-    fab: {
-      fill: true
-    },
-    raised: {
-      fill: true
-    },
-    colored: {
-      fill: true
-    }
+    accent: Boolean,
+    primary: Boolean,
+    miniFab: Boolean,
+    fab: Boolean,
+    raised: Boolean,
+    colored: Boolean
   },
-  mixins: [propFill],
-  ready () {
+  mounted () {
     componentHandler.upgradeElement(this.$el)
   }
 }

--- a/src/mixins/prop-fill.js
+++ b/src/mixins/prop-fill.js
@@ -1,12 +1,13 @@
 // When declaring a prop with no value it should be evaluated to true
 // but '' is falsy. As a solution add the
 export default {
-  beforeCompile () {
-    if (!this._props) return
-    for (let prop of Object.keys(this._props)) {
-      let data = this._props[prop]
-      if (data.options.fill && data.raw === '') {
-        this[prop] = prop
+  created () {
+    if (!this.$options.props) return
+    for (let prop of Object.keys(this.$options.props)) {
+      let data = this.$options.propsData[prop]
+      let options = this.$options.props[prop]
+      if (options.fill && data === '') {
+        // this.$options.propsData[prop] = prop
       }
     }
   }

--- a/src/mixins/toggle.js
+++ b/src/mixins/toggle.js
@@ -1,9 +1,7 @@
 export default {
   props: {
     checked: {
-      type: [Array, Boolean, Number],
-      required: true,
-      twoWay: true
+      required: true
     },
     disabled: {
       required: false
@@ -13,13 +11,9 @@ export default {
       required: false
     }
   },
-  computed: {
-    isChecked () {
-      if (this.checked instanceof Array) {
-        return this.checked.indexOf(this.value) >= 0
-      } else {
-        return this.checked
-      }
+  methods: {
+    fireChange: function (event) {
+      this.$emit('change', event)
     }
   }
 }

--- a/src/mixins/toggle.js
+++ b/src/mixins/toggle.js
@@ -8,14 +8,14 @@ export default {
       required: false
     },
     id: String,
-    checkValue: {
+    selectedValue: {
       required: false
     }
   },
   computed: {
     isChecked () {
       if (this.value instanceof Array) {
-        return this.value.indexOf(this.checkValue) >= 0
+        return this.value.indexOf(this.selectedValue) >= 0
       } else {
         return this.value
       }
@@ -25,10 +25,10 @@ export default {
     this.checked = this.value
   },
   watch: {
-    value: function (value, oldValue) {
+    value: function (value) {
       this.checked = value
     },
-    checked: function (value, oldValue) {
+    checked: function (value) {
       this.$emit('input', value)
     }
   }

--- a/src/mixins/toggle.js
+++ b/src/mixins/toggle.js
@@ -1,19 +1,35 @@
 export default {
   props: {
-    checked: {
+    value: {
+      type: [Array, Boolean, Number],
       required: true
     },
     disabled: {
       required: false
     },
     id: String,
-    value: {
+    checkValue: {
       required: false
     }
   },
-  methods: {
-    fireChange: function (event) {
-      this.$emit('change', event)
+  computed: {
+    isChecked () {
+      if (this.value instanceof Array) {
+        return this.value.indexOf(this.checkValue) >= 0
+      } else {
+        return this.value
+      }
+    }
+  },
+  beforeMount: function () {
+    this.checked = this.value
+  },
+  watch: {
+    value: function (value, oldValue) {
+      this.checked = value
+    },
+    checked: function (value, oldValue) {
+      this.$emit('input', value)
     }
   }
 }

--- a/src/progress.vue
+++ b/src/progress.vue
@@ -1,5 +1,5 @@
 <template lang="jade">
-.mdl-progress.mdl-js-progress(v-bind:class='{ "mdl-progress__indeterminate": indeterminate }')
+.mdl-progress.mdl-js-progress(v-bind:class="{ 'mdl-progress__indeterminate': indeterminate }")
 </template>
 
 <script>
@@ -13,11 +13,9 @@ export default {
     buffer: {
       required: false
     },
-    indeterminate: {
-      fill: true
-    }
+    indeterminate: Boolean
   },
-  ready () {
+  mounted () {
     componentHandler.upgradeElement(this.$el, 'MaterialProgress')
 
     if (this.progress != null) {
@@ -29,7 +27,6 @@ export default {
       this.$el.MaterialProgress.setBuffer(this.buffer)
       this.$watch('buffer', val => this.$el.MaterialProgress.setBuffer(val))
     }
-  },
-  mixins: [propFill]
+  }
 }
 </script>

--- a/src/progress.vue
+++ b/src/progress.vue
@@ -11,7 +11,9 @@ export default {
     buffer: {
       required: false
     },
-    indeterminate: Boolean
+    indeterminate: {
+      required: false
+    }
   },
   mounted () {
     componentHandler.upgradeElement(this.$el, 'MaterialProgress')

--- a/src/progress.vue
+++ b/src/progress.vue
@@ -3,8 +3,6 @@
 </template>
 
 <script>
-import propFill from './mixins/prop-fill'
-
 export default {
   props: {
     progress: {

--- a/src/select.vue
+++ b/src/select.vue
@@ -84,7 +84,7 @@ export default {
     this.setName()
   },
   watch: {
-    value: function () {
+    value () {
       this.setName()
     }
   }

--- a/src/select.vue
+++ b/src/select.vue
@@ -35,11 +35,8 @@ export default {
     }
   },
   methods: {
-    selectValue (option) {
-      this.value = option.value
-      this.name = option.name
-      let event = new Event('change')
-      this.$el.dispatchEvent(event)
+    selectValue ({value}) {
+      this.$emit('input', value)
     },
     setName () {
       this.name = null
@@ -87,7 +84,7 @@ export default {
     this.setName()
   },
   watch: {
-    value () {
+    value: function () {
       this.setName()
     }
   }

--- a/src/select.vue
+++ b/src/select.vue
@@ -18,8 +18,8 @@
 </style>
 
 <template lang="jade">
-.mdl-textfield.mdl-js-textfield.mdl-textfield--floating-label.getmdl-select(v-el:textfield)
-  input.mdl-textfield__input(v-bind:id.once='id', v-el:input, v-model='name', type='text', readonly='', tabindex='-1')
+.mdl-textfield.mdl-js-textfield.mdl-textfield--floating-label.getmdl-select(ref="textfield")
+  input.mdl-textfield__input(v-bind:id.once='id', ref="input", v-model='name', type='text', readonly='', tabindex='-1')
   label(v-bind:for.once='id')
     i.mdl-icon-toggle__label.material-icons keyboard_arrow_down
   label.mdl-textfield__label(v-bind:for.once='id') {{label}}
@@ -48,8 +48,8 @@ export default {
         if (this.value === option.value) this.name = option.name
       }
       if (!this.name) this.name = this.value
-      this.$els.textfield.MaterialTextfield.change(this.name)
-      this.$els.textfield.MaterialTextfield.boundBlurHandler()
+      this.$refs.textfield.MaterialTextfield.change(this.name)
+      this.$refs.textfield.MaterialTextfield.boundBlurHandler()
     }
   },
   computed: {
@@ -82,7 +82,7 @@ export default {
       required: true
     }
   },
-  ready () {
+  mounted () {
     componentHandler.upgradeElements(this.$el)
     this.setName()
   },

--- a/src/slider.vue
+++ b/src/slider.vue
@@ -31,7 +31,7 @@ export default {
       fill: true
     }
   },
-  ready () {
+  mounted () {
     componentHandler.upgradeElement(this.$el, 'MaterialSlider')
 
     this.$el.MaterialSlider.change(this.value)

--- a/src/snackbar.vue
+++ b/src/snackbar.vue
@@ -6,12 +6,13 @@
 
 <script>
 export default {
-  props: ['displayOn'],
   mounted () {
     componentHandler.upgradeElement(this.$el, 'MaterialSnackbar')
-    this.$on(this.displayOn, (snackarConfig) => {
-      this.$el.MaterialSnackbar.showSnackbar(snackarConfig)
-    })
+  },
+  methods: {
+    showSnackbar: function (config) {
+      this.$el.MaterialSnackbar.showSnackbar(config)
+    }
   }
 }
 </script>

--- a/src/snackbar.vue
+++ b/src/snackbar.vue
@@ -7,7 +7,7 @@
 <script>
 export default {
   props: ['displayOn'],
-  ready () {
+  mounted () {
     componentHandler.upgradeElement(this.$el, 'MaterialSnackbar')
     this.$on(this.displayOn, (snackarConfig) => {
       this.$el.MaterialSnackbar.showSnackbar(snackarConfig)

--- a/src/snackbar.vue
+++ b/src/snackbar.vue
@@ -6,13 +6,24 @@
 
 <script>
 export default {
+  props: {
+    displayOn: {
+      type: String,
+      required: true
+    },
+    eventSource: {
+      type: Object,
+      required: false,
+      default: function () {
+        return this.$root
+      }
+    }
+  },
   mounted () {
     componentHandler.upgradeElement(this.$el, 'MaterialSnackbar')
-  },
-  methods: {
-    showSnackbar: function (config) {
-      this.$el.MaterialSnackbar.showSnackbar(config)
-    }
+    this.eventSource.$on(this.displayOn, (snackbarConfig) => {
+      this.$el.MaterialSnackbar.showSnackbar(snackbarConfig)
+    })
   }
 }
 </script>

--- a/src/spinner.vue
+++ b/src/spinner.vue
@@ -1,5 +1,5 @@
 <template lang="jade">
-.mdl-spinner.mdl-js-spinner(v-bind:class="{ 'mdl-spinner--single-color': singleColor, 'is-active': active }")
+.mdl-spinner.mdl-js-spinner(v-bind:class="{ 'mdl-spinner--single-color': singleColor, 'is-active': active, 'is-upgraded': upgraded }")
 </template>
 
 <script>
@@ -11,8 +11,14 @@ export default {
     },
     singleColor: Boolean
   },
+  data: function () {
+    return {
+      upgraded: false
+    }
+  },
   mounted () {
     componentHandler.upgradeElement(this.$el, 'MaterialSpinner')
+    this.upgraded = true
   }
 }
 </script>

--- a/src/spinner.vue
+++ b/src/spinner.vue
@@ -3,8 +3,6 @@
 </template>
 
 <script>
-import propFill from './mixins/prop-fill'
-
 export default {
   props: {
     active: {

--- a/src/spinner.vue
+++ b/src/spinner.vue
@@ -1,5 +1,5 @@
 <template lang="jade">
-.mdl-spinner.mdl-js-spinner(v-bind:class='{ "mdl-spinner--single-color": singleColor, "is-active": active }')
+.mdl-spinner.mdl-js-spinner(v-bind:class="{ 'mdl-spinner--single-color': singleColor, 'is-active': active }")
 </template>
 
 <script>
@@ -11,13 +11,10 @@ export default {
       default: true,
       type: Boolean
     },
-    singleColor: {
-      fill: true
-    }
+    singleColor: Boolean
   },
-  ready () {
+  mounted () {
     componentHandler.upgradeElement(this.$el, 'MaterialSpinner')
-  },
-  mixins: [propFill]
+  }
 }
 </script>

--- a/src/tabs/tab-link.vue
+++ b/src/tabs/tab-link.vue
@@ -2,7 +2,7 @@
   <a class="mdl-tabs__tab"
      href="#"
   >{{tab.title}}
-    <span v-el:ripple
+    <span ref="ripple"
           v-show="!noRippleEffect"
           class="mdl-tabs__ripple-container mdl-js-ripple-effect">
       <span class="mdl-ripple"></span>
@@ -18,8 +18,8 @@ export default {
       required: false
     }
   },
-  ready () {
-    componentHandler.upgradeElement(this.$els.ripple, 'MaterialRipple')
+  mounted () {
+    componentHandler.upgradeElement(this.$refs.ripple, 'MaterialRipple')
   }
 }
 </script>

--- a/src/tabs/tab.vue
+++ b/src/tabs/tab.vue
@@ -38,7 +38,7 @@ export default {
       this.$parent.updateTab(tabToOject(oldTab), this.tabData)
     }
   },
-  ready () {
+  mounted () {
     this.$parent.addTab(this.tabData)
   },
   beforeDestroy () {

--- a/src/tabs/tabs.vue
+++ b/src/tabs/tabs.vue
@@ -5,10 +5,10 @@
       <tab-link
           class="mdl-tabs__tab"
           v-for="tab in tabs"
-          track-by="id"
+          :key="tab.id"
           :no-ripple-effect="noRippleEffect"
           :class="{ 'is-active': isSelected(tab) }"
-          @click.prevent="selectTab(tab)"
+          @click.native="selectTab(tab)"
           :tab="tab"
       ></tab-link>
     </div>
@@ -18,7 +18,6 @@
 </template>
 
 <script>
-import propFill from '../mixins/prop-fill'
 import TabLink from './tab-link.vue'
 
 // indexOf with object
@@ -33,12 +32,12 @@ function findTabIndex (tabs, id) {
 
 export default {
   props: {
-    selected: {
-      required: true,
-      twoWay: true
+    value: {
+      required: false,
+      type: [String, Number]
     },
     noRippleEffect: {
-      fill: true,
+      type: Boolean,
       required: false
     }
   },
@@ -49,10 +48,10 @@ export default {
   },
   methods: {
     selectTab ({id}) {
-      this.selected = id
+      this.$emit('input', id)
     },
     isSelected ({id}) {
-      return id === this.selected
+      return id === this.value
     },
     addTab (tab) {
       // TODO check for duplicates and throw error
@@ -67,7 +66,6 @@ export default {
       if (index > -1) this.tabs.splice(index, 1)
     }
   },
-  mixins: [propFill],
   components: {TabLink}
 }
 </script>

--- a/src/textfield.vue
+++ b/src/textfield.vue
@@ -15,8 +15,6 @@
 </template>
 
 <script>
-import propFill from './mixins/prop-fill'
-
 export default {
   props: {
     maxlength: {

--- a/src/textfield.vue
+++ b/src/textfield.vue
@@ -1,15 +1,15 @@
 <template lang="jade">
-.mdl-textfield.mdl-js-textfield(v-bind:class='{"mdl-textfield--floating-label": floatingLabel, "mdl-textfield--expandable": expandable, "is-dirty": isDirty, "is-disabled": disabled}')
+.mdl-textfield.mdl-js-textfield(v-bind:class="{'mdl-textfield--floating-label': floatingLabel, 'mdl-textfield--expandable': expandable, 'is-dirty': isDirty, 'is-disabled': disabled}")
   slot(v-if='expandable' name='expandable-button')
     label.mdl-button.mdl-js-button.mdl-button--icon(v-bind:for.once='id')
       i.material-icons {{expandable}}
-  div(v-bind:class='{"mdl-textfield__expandable-holder": expandable}')
+  div(v-bind:class="{'mdl-textfield__expandable-holder': expandable}")
     slot(v-if='textarea' name='textarea')
-      textarea.mdl-textfield__input(type='text' v-model='value' v-bind:required='required' v-bind:id.once='id' v-bind:rows='rows' v-bind:disabled='disabled' v-bind:readonly='readonly' v-bind:maxlength='maxlength')
+      textarea.mdl-textfield__input(type='text' v-bind:value='value' v-on:input='fireInputEvent' v-bind:required='required' v-bind:id.once='id' v-bind:rows='rows' v-bind:disabled='disabled' v-bind:readonly='readonly' v-bind:maxlength='maxlength')
     slot(v-else name='input')
-      input.mdl-textfield__input(v-bind:type='type' v-model='value' v-bind:id.once='id' v-bind:pattern='pattern' v-bind:disabled='disabled' v-bind:required='required' v-bind:readonly='readonly' v-bind:maxlength='maxlength')
+      input.mdl-textfield__input(v-bind:type='type' v-bind:value='value' v-on:input='fireInputEvent' v-bind:id.once='id' v-bind:pattern='pattern' v-bind:disabled='disabled' v-bind:required='required' v-bind:readonly='readonly' v-bind:maxlength='maxlength')
     slot(name='label')
-      label.mdl-textfield__label(v-bind:for.once='id') {{label}}
+      label.mdl-textfield__label(v-bind:for.once='id') {{displayLabel}}
     slot(name='error')
       label.mdl-textfield__error(v-if='error') {{error}}
 </template>
@@ -55,25 +55,24 @@ export default {
     label: String,
     pattern: String,
     error: String,
-    textarea: {
-      fill: true
-    },
-    floatingLabel: {
-      required: false
-    }
+    textarea: Boolean,
+    floatingLabel: [Boolean, String]
   },
   computed: {
+    displayLabel () {
+      return this.label || this.floatingLabel
+    },
     isDirty () {
       return '' + this.value
     }
   },
-  ready () {
-    componentHandler.upgradeElement(this.$el)
-    if (this.floatingLabel && this.label == null) {
-      this.label = this.floatingLabel
-      this.$watch('floatingLabel', (val) => this.label = val)
+  methods: {
+    fireInputEvent: function (event) {
+      this.$emit('input', event.target.value)
     }
   },
-  mixins: [propFill]
+  mounted () {
+    componentHandler.upgradeElement(this.$el)
+  }
 }
 </script>

--- a/src/toggles/checkbox.vue
+++ b/src/toggles/checkbox.vue
@@ -1,6 +1,6 @@
 <template lang="jade">
 label.mdl-checkbox.mdl-js-checkbox(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': isChecked, 'is-upgraded': upgraded }")
-  input.mdl-checkbox__input(v-bind:value='checkValue' type="checkbox" v-bind:id.once='id' v-model='checked' v-bind:disabled='disabled')
+  input.mdl-checkbox__input(v-bind:value='selectedValue' type="checkbox" v-bind:id.once='id' v-model='checked' v-bind:disabled='disabled')
   span.mdl-checkbox__label
     slot
 </template>

--- a/src/toggles/checkbox.vue
+++ b/src/toggles/checkbox.vue
@@ -1,6 +1,6 @@
 <template lang="jade">
-label.mdl-checkbox.mdl-js-checkbox(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': isChecked }")
-  input.mdl-checkbox__input(v-bind:value='value' type='checkbox' v-bind:id.once='id' v-model='checked' v-bind:disabled='disabled')
+label.mdl-checkbox.mdl-js-checkbox(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': checked, 'is-upgraded': upgraded }")
+  input.mdl-checkbox__input(v-bind:value='value' type='checkbox' v-bind:id.once='id' v-bind:checked='checked' v-on:change='fireChange' v-bind:disabled='disabled')
   span.mdl-checkbox__label
     slot
 </template>
@@ -8,8 +8,14 @@ label.mdl-checkbox.mdl-js-checkbox(v-bind:for.once='id' v-bind:class="{ 'is-disa
 <script>
 import common from '../mixins/toggle'
 export default {
+  data: function () {
+    return {
+      upgraded: false
+    }
+  },
   mounted () {
     componentHandler.upgradeElements(this.$el)
+    this.upgraded = true
   },
   mixins: [common]
 }

--- a/src/toggles/checkbox.vue
+++ b/src/toggles/checkbox.vue
@@ -1,5 +1,5 @@
 <template lang="jade">
-label.mdl-checkbox.mdl-js-checkbox(v-bind:for.once='id' v-bind:class='{ "is-disabled": disabled, "is-checked": isChecked }')
+label.mdl-checkbox.mdl-js-checkbox(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': isChecked }")
   input.mdl-checkbox__input(v-bind:value='value' type='checkbox' v-bind:id.once='id' v-model='checked' v-bind:disabled='disabled')
   span.mdl-checkbox__label
     slot
@@ -8,7 +8,7 @@ label.mdl-checkbox.mdl-js-checkbox(v-bind:for.once='id' v-bind:class='{ "is-disa
 <script>
 import common from '../mixins/toggle'
 export default {
-  ready () {
+  mounted () {
     componentHandler.upgradeElements(this.$el)
   },
   mixins: [common]

--- a/src/toggles/checkbox.vue
+++ b/src/toggles/checkbox.vue
@@ -1,6 +1,6 @@
 <template lang="jade">
-label.mdl-checkbox.mdl-js-checkbox(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': checked, 'is-upgraded': upgraded }")
-  input.mdl-checkbox__input(v-bind:value='value' type='checkbox' v-bind:id.once='id' v-bind:checked='checked' v-on:change='fireChange' v-bind:disabled='disabled')
+label.mdl-checkbox.mdl-js-checkbox(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': isChecked, 'is-upgraded': upgraded }")
+  input.mdl-checkbox__input(v-bind:value='checkValue' type="checkbox" v-bind:id.once='id' v-model='checked' v-bind:disabled='disabled')
   span.mdl-checkbox__label
     slot
 </template>
@@ -10,6 +10,7 @@ import common from '../mixins/toggle'
 export default {
   data: function () {
     return {
+      checked: null,
       upgraded: false
     }
   },

--- a/src/toggles/icon-toggle.vue
+++ b/src/toggles/icon-toggle.vue
@@ -1,6 +1,6 @@
 <template lang="jade">
 label.mdl-icon-toggle.mdl-js-icon-toggle(v-bind:for.once='id' class='' v-bind:class="{ 'is-disabled': disabled, 'is-checked': checked, 'is-upgraded': upgraded }")
-  input.mdl-icon-toggle__input(v-bind:value='checkValue' type='checkbox' v-bind:id.once='id' v-model='checked' v-bind:disabled='disabled')
+  input.mdl-icon-toggle__input(v-bind:value='selectedValue' type='checkbox' v-bind:id.once='id' v-model='checked' v-bind:disabled='disabled')
   i.mdl-icon-toggle__label.material-icons {{icon}}
 </template>
 

--- a/src/toggles/icon-toggle.vue
+++ b/src/toggles/icon-toggle.vue
@@ -1,6 +1,6 @@
 <template lang="jade">
 label.mdl-icon-toggle.mdl-js-icon-toggle(v-bind:for.once='id' class='' v-bind:class="{ 'is-disabled': disabled, 'is-checked': checked, 'is-upgraded': upgraded }")
-  input.mdl-icon-toggle__input(v-bind:value='value' type='checkbox' v-bind:id.once='id' v-bind:checked='checked' v-on:change='fireChange' v-bind:disabled='disabled')
+  input.mdl-icon-toggle__input(v-bind:value='checkValue' type='checkbox' v-bind:id.once='id' v-model='checked' v-bind:disabled='disabled')
   i.mdl-icon-toggle__label.material-icons {{icon}}
 </template>
 
@@ -10,6 +10,7 @@ import common from '../mixins/toggle'
 export default {
   data: function () {
     return {
+      checked: null,
       upgraded: false
     }
   },

--- a/src/toggles/icon-toggle.vue
+++ b/src/toggles/icon-toggle.vue
@@ -1,5 +1,5 @@
 <template lang="jade">
-label.mdl-icon-toggle.mdl-js-icon-toggle(v-bind:for.once='id' v-bind:class='{ "is-disabled": disabled, "is-checked": isChecked }')
+label.mdl-icon-toggle.mdl-js-icon-toggle(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': isChecked }")
   input.mdl-icon-toggle__input(v-bind:value='value' type='checkbox' v-bind:id.once='id' v-model='checked' v-bind:disabled='disabled')
   i.mdl-icon-toggle__label.material-icons {{icon}}
 </template>
@@ -15,7 +15,7 @@ export default {
     }
   },
   mixins: [common],
-  ready () {
+  mounted () {
     componentHandler.upgradeElements(this.$el)
   }
 }

--- a/src/toggles/icon-toggle.vue
+++ b/src/toggles/icon-toggle.vue
@@ -1,6 +1,6 @@
 <template lang="jade">
-label.mdl-icon-toggle.mdl-js-icon-toggle(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': isChecked }")
-  input.mdl-icon-toggle__input(v-bind:value='value' type='checkbox' v-bind:id.once='id' v-model='checked' v-bind:disabled='disabled')
+label.mdl-icon-toggle.mdl-js-icon-toggle(v-bind:for.once='id' class='' v-bind:class="{ 'is-disabled': disabled, 'is-checked': checked, 'is-upgraded': upgraded }")
+  input.mdl-icon-toggle__input(v-bind:value='value' type='checkbox' v-bind:id.once='id' v-bind:checked='checked' v-on:change='fireChange' v-bind:disabled='disabled')
   i.mdl-icon-toggle__label.material-icons {{icon}}
 </template>
 
@@ -8,6 +8,11 @@ label.mdl-icon-toggle.mdl-js-icon-toggle(v-bind:for.once='id' v-bind:class="{ 'i
 import common from '../mixins/toggle'
 
 export default {
+  data: function () {
+    return {
+      upgraded: false
+    }
+  },
   props: {
     icon: {
       required: true,
@@ -17,6 +22,7 @@ export default {
   mixins: [common],
   mounted () {
     componentHandler.upgradeElements(this.$el)
+    this.upgraded = true
   }
 }
 </script>

--- a/src/toggles/radio.vue
+++ b/src/toggles/radio.vue
@@ -1,6 +1,6 @@
 <template lang="jade">
-label.mdl-radio.mdl-js-radio(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': checked, 'is-upgraded': upgraded }")
-  input.mdl-radio__button(v-bind:id.once='id' type='radio' v-bind:name.once='name' v-bind:value='value' v-bind:checked='checked' v-on:change='fireChangedEvent' v-bind:disabled='disabled')
+label.mdl-radio.mdl-js-radio(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': isChecked, 'is-upgraded': upgraded }")
+  input.mdl-radio__button(v-bind:id.once='id' type='radio' v-bind:name.once='name' v-bind:value='radioValue' v-bind:checked="isChecked" v-on:change="fireChangedEvent" v-bind:disabled='disabled')
   span.mdl-radio__label
     slot
 </template>
@@ -15,17 +15,22 @@ export default {
   props: {
     id: String,
     name: String,
-    value: {
+    radioValue: {
       required: true
     },
-    checked: {
+    value: {
       required: true
     },
     disabled: Boolean
   },
+  computed: {
+    isChecked: function () {
+      return this.value === this.radioValue
+    }
+  },
   methods: {
-    fireChangedEvent (event) {
-      this.$emit('change', this.value)
+    fireChangedEvent () {
+      this.$emit('input', this.radioValue)
     }
   },
   mounted () {

--- a/src/toggles/radio.vue
+++ b/src/toggles/radio.vue
@@ -1,6 +1,6 @@
 <template lang="jade">
 label.mdl-radio.mdl-js-radio(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': isChecked, 'is-upgraded': upgraded }")
-  input.mdl-radio__button(v-bind:id.once='id' type='radio' v-bind:name.once='name' v-bind:value='radioValue' v-bind:checked="isChecked" v-on:change="fireChangedEvent" v-bind:disabled='disabled')
+  input.mdl-radio__button(v-bind:id.once='id' type='radio' v-bind:name.once='name' v-bind:value='selectedValue' v-bind:checked="isChecked" v-on:change="fireChangedEvent" v-bind:disabled='disabled')
   span.mdl-radio__label
     slot
 </template>
@@ -15,7 +15,7 @@ export default {
   props: {
     id: String,
     name: String,
-    radioValue: {
+    selectedValue: {
       required: true
     },
     value: {
@@ -25,12 +25,12 @@ export default {
   },
   computed: {
     isChecked: function () {
-      return this.value === this.radioValue
+      return this.value === this.selectedValue
     }
   },
   methods: {
     fireChangedEvent () {
-      this.$emit('input', this.radioValue)
+      this.$emit('input', this.selectedValue)
     }
   },
   mounted () {

--- a/src/toggles/radio.vue
+++ b/src/toggles/radio.vue
@@ -1,6 +1,6 @@
 <template lang="jade">
-label.mdl-radio.mdl-js-radio(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': isChecked }")
-  input.mdl-radio__button(v-bind:id.once='id' type='radio' v-bind:name.once='name' v-bind:value='value' v-model='checked' v-bind:disabled='disabled')
+label.mdl-radio.mdl-js-radio(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': checked }")
+  input.mdl-radio__button(v-bind:id.once='id' type='radio' v-bind:name.once='name' v-bind:value='value' v-bind:checked='checked' v-on:change='fireChangedEvent' v-bind:disabled='disabled')
   span.mdl-radio__label
     slot
 </template>
@@ -16,14 +16,13 @@ export default {
       required: true
     },
     checked: {
-      required: true,
-      twoWay: true
+      required: true
     },
     disabled: Boolean
   },
-  computed: {
-    isChecked () {
-      return this.checked === this.value
+  methods: {
+    fireChangedEvent (event) {
+      this.$emit('change', this.value)
     }
   },
   mounted () {

--- a/src/toggles/radio.vue
+++ b/src/toggles/radio.vue
@@ -6,8 +6,6 @@ label.mdl-radio.mdl-js-radio(v-bind:for.once='id' v-bind:class="{ 'is-disabled':
 </template>
 
 <script>
-import propFill from '../mixins/prop-fill'
-
 export default {
   data: function () {
     return {

--- a/src/toggles/radio.vue
+++ b/src/toggles/radio.vue
@@ -1,5 +1,5 @@
 <template lang="jade">
-label.mdl-radio.mdl-js-radio(v-bind:for.once='id' v-bind:class='{ "is-disabled": disabled, "is-checked": isChecked }')
+label.mdl-radio.mdl-js-radio(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': isChecked }")
   input.mdl-radio__button(v-bind:id.once='id' type='radio' v-bind:name.once='name' v-bind:value='value' v-model='checked' v-bind:disabled='disabled')
   span.mdl-radio__label
     slot
@@ -19,18 +19,15 @@ export default {
       required: true,
       twoWay: true
     },
-    disabled: {
-      fill: true
-    }
+    disabled: Boolean
   },
   computed: {
     isChecked () {
       return this.checked === this.value
     }
   },
-  ready () {
+  mounted () {
     componentHandler.upgradeElements(this.$el)
-  },
-  mixins: [propFill]
+  }
 }
 </script>

--- a/src/toggles/radio.vue
+++ b/src/toggles/radio.vue
@@ -1,5 +1,5 @@
 <template lang="jade">
-label.mdl-radio.mdl-js-radio(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': checked }")
+label.mdl-radio.mdl-js-radio(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': checked, 'is-upgraded': upgraded }")
   input.mdl-radio__button(v-bind:id.once='id' type='radio' v-bind:name.once='name' v-bind:value='value' v-bind:checked='checked' v-on:change='fireChangedEvent' v-bind:disabled='disabled')
   span.mdl-radio__label
     slot
@@ -9,6 +9,11 @@ label.mdl-radio.mdl-js-radio(v-bind:for.once='id' v-bind:class="{ 'is-disabled':
 import propFill from '../mixins/prop-fill'
 
 export default {
+  data: function () {
+    return {
+      upgraded: false
+    }
+  },
   props: {
     id: String,
     name: String,
@@ -27,6 +32,7 @@ export default {
   },
   mounted () {
     componentHandler.upgradeElements(this.$el)
+    this.upgraded = true
   }
 }
 </script>

--- a/src/toggles/switch.vue
+++ b/src/toggles/switch.vue
@@ -1,6 +1,6 @@
 <template lang="jade">
-label.mdl-switch.mdl-js-switch(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': checked, 'is-upgraded': upgraded }")
-  input.mdl-switch__input(v-bind:value='value' type='checkbox' v-bind:id.once='id' v-bind:checked='checked' v-on:change='fireChange' v-bind:disabled='disabled')
+label.mdl-switch.mdl-js-switch(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': isChecked, 'is-upgraded': upgraded }")
+  input.mdl-switch__input(v-bind:value='checkValue' type='checkbox' v-bind:id.once='id' v-model:checked='checked' v-bind:disabled='disabled')
   span.mdl-switch__label
     slot
 </template>
@@ -11,6 +11,7 @@ import common from '../mixins/toggle'
 export default {
   data: function () {
     return {
+      checked: null,
       upgraded: false
     }
   },

--- a/src/toggles/switch.vue
+++ b/src/toggles/switch.vue
@@ -1,6 +1,6 @@
 <template lang="jade">
-label.mdl-switch.mdl-js-switch(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': isChecked }")
-  input.mdl-switch__input(v-bind:value='value' type='checkbox' v-bind:id.once='id' v-model='checked' v-bind:disabled='disabled')
+label.mdl-switch.mdl-js-switch(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': checked, 'is-upgraded': upgraded }")
+  input.mdl-switch__input(v-bind:value='value' type='checkbox' v-bind:id.once='id' v-bind:checked='checked' v-on:change='fireChange' v-bind:disabled='disabled')
   span.mdl-switch__label
     slot
 </template>
@@ -9,9 +9,15 @@ label.mdl-switch.mdl-js-switch(v-bind:for.once='id' v-bind:class="{ 'is-disabled
 import common from '../mixins/toggle'
 
 export default {
+  data: function () {
+    return {
+      upgraded: false
+    }
+  },
   mixins: [common],
   mounted () {
     componentHandler.upgradeElements(this.$el)
+    this.upgraded = true
   }
 }
 </script>

--- a/src/toggles/switch.vue
+++ b/src/toggles/switch.vue
@@ -1,6 +1,6 @@
 <template lang="jade">
 label.mdl-switch.mdl-js-switch(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': isChecked, 'is-upgraded': upgraded }")
-  input.mdl-switch__input(v-bind:value='checkValue' type='checkbox' v-bind:id.once='id' v-model:checked='checked' v-bind:disabled='disabled')
+  input.mdl-switch__input(v-bind:value='selectedValue' type='checkbox' v-bind:id.once='id' v-model:checked='checked' v-bind:disabled='disabled')
   span.mdl-switch__label
     slot
 </template>

--- a/src/toggles/switch.vue
+++ b/src/toggles/switch.vue
@@ -1,5 +1,5 @@
 <template lang="jade">
-label.mdl-switch.mdl-js-switch(v-bind:for.once='id' v-bind:class='{ "is-disabled": disabled, "is-checked": isChecked }')
+label.mdl-switch.mdl-js-switch(v-bind:for.once='id' v-bind:class="{ 'is-disabled': disabled, 'is-checked': isChecked }")
   input.mdl-switch__input(v-bind:value='value' type='checkbox' v-bind:id.once='id' v-model='checked' v-bind:disabled='disabled')
   span.mdl-switch__label
     slot
@@ -10,7 +10,7 @@ import common from '../mixins/toggle'
 
 export default {
   mixins: [common],
-  ready () {
+  mounted () {
     componentHandler.upgradeElements(this.$el)
   }
 }

--- a/src/tooltip.vue
+++ b/src/tooltip.vue
@@ -1,5 +1,5 @@
 <template lang="jade">
-.mdl-tooltip(v-bind:for='for' v-bind:class='{"mdl-tooltip--large": large}')
+.mdl-tooltip(v-bind:for='target' v-bind:class="{'mdl-tooltip--large': large}")
   slot
 </template>
 
@@ -8,17 +8,14 @@ import propFill from './mixins/prop-fill'
 
 export default {
   props: {
-    for: {
+    target: {
       required: true,
       type: String
     },
-    large: {
-      fill: true
-    }
+    large: Boolean
   },
-  ready () {
+  mounted () {
     componentHandler.upgradeElement(this.$el, 'MaterialTooltip')
-  },
-  mixins: [propFill]
+  }
 }
 </script>

--- a/src/tooltip.vue
+++ b/src/tooltip.vue
@@ -4,8 +4,6 @@
 </template>
 
 <script>
-import propFill from './mixins/prop-fill'
-
 export default {
   props: {
     target: {

--- a/test/components/Card.vue
+++ b/test/components/Card.vue
@@ -28,8 +28,7 @@
   br
   p Normal card
   mdl-card#card(:title='title',
-    v-ref:card,
-    v-el:card,
+    ref='card',
     :subtitle='subtitle',
     :media='media',
     :supporting-text='supportingText',
@@ -39,12 +38,14 @@
     menu='cardMenu'
     )
   mdl-card#menu(
+    ref='cardMenu',
     title='Menu',
-    :supporting-text='"Menu was called " + menuCallCount + " times."',
-    menu='cardMenu'
+    :supporting-text="'Menu was called ' + menuCallCount + ' times.'",
+    menu='cardMenu',
+    v-on:cardMenu='increaseMenuCount'
   )
   br
-  mdl-textfield(:value.sync='title', floating-label='Card Title')
+  mdl-textfield(v-model='title', floating-label='Card Title')
   mdl-textfield(:value.sync='subtitle', floating-label='Card subtitle')
   mdl-textfield(:value.sync='media', floating-label='Card Media')
   mdl-textfield(textarea, :value.sync='supportingText', floating-label='Card supporting text')
@@ -62,8 +63,8 @@
       h2.mdl-card__title-text Title from slot
   br
   mdl-card(supporting-text='This card has no title \n Ha ha')
-  mdl-card#actions-button(:title='"Emitted events " + num', actions='increaseNum', actions-text='Increase count')
-  mdl-card(title="Empty slot", :supporting-text='""', :actions='""')
+  mdl-card#actions-button(ref='increaseCard', :title="'Emitted events ' + num", actions='increaseNum', actions-text='Increase count', v-on:increaseNum='increaseNum')
+  mdl-card(title="Empty slot", :supporting-text="''", :actions="''")
 </template>
 
 <script>
@@ -81,12 +82,11 @@ export default {
       supportingText: 'Here is some supporting text'
     }
   },
-  events: {
-    cardMenu () {
+  methods: {
+    increaseMenuCount: function () {
       this.menuCallCount++
-      return true // stop propagation
     },
-    increaseNum () {
+    increaseNum: function () {
       this.num++
     }
   }

--- a/test/components/Checkbox.vue
+++ b/test/components/Checkbox.vue
@@ -11,7 +11,7 @@ div
   h3 vue
   // We can also use the jade syntax #id for literal ids
   mdl-checkbox.added-class(id='check-dyn' v-bind:checked.sync='check') Dynamic {{check}}
-  mdl-checkbox(id='check' v-bind:checked.sync='check' v-bind:disabled='disabled') Check me
+  mdl-checkbox#check(v-bind:checked.sync='check' v-bind:disabled='disabled') Check me
   mdl-checkbox#number(v-bind:checked.sync='numCheck') My value is a number
   input#classic(type='checkbox' v-model='check')
   span Classic checkbox
@@ -19,7 +19,7 @@ div
   span Disable
   mdl-checkbox(v-if='disabled' id='v-if' v-bind:checked.sync='check' v-bind:disabled='disabled') v-if
   mdl-checkbox(v-for='n in 3' v-bind:value='indexId(n)' v-bind:id='indexId(n)' v-bind:checked.sync='checks') v-for {{indexId(n)}}
-  p#checks {{checks | json}}
+  p#checks {{checks}}
 </template>
 
 <script lang="babel">

--- a/test/components/Checkbox.vue
+++ b/test/components/Checkbox.vue
@@ -10,15 +10,15 @@ div
     span.mdl-checkbox__label No ripple
   h3 vue
   // We can also use the jade syntax #id for literal ids
-  mdl-checkbox.added-class(id='check-dyn' v-bind:checked.sync='check') Dynamic {{check}}
-  mdl-checkbox#check(v-bind:checked.sync='check' v-bind:disabled='disabled') Check me
-  mdl-checkbox#number(v-bind:checked.sync='numCheck') My value is a number
+  mdl-checkbox.added-class(id='check-dyn' type="checkbox" v-model='check') Dynamic {{check}}
+  mdl-checkbox#check(type="checkbox" v-model='check' v-bind:disabled='disabled') Check me
+  mdl-checkbox#number(type="checkbox" v-model='numCheck') My value is a number
   input#classic(type='checkbox' v-model='check')
   span Classic checkbox
   input#disable(type='checkbox' v-model='disabled')
   span Disable
-  mdl-checkbox(v-if='disabled' id='v-if' v-bind:checked.sync='check' v-bind:disabled='disabled') v-if
-  mdl-checkbox(v-for='n in 3' v-bind:value='indexId(n)' v-bind:id='indexId(n)' v-bind:checked.sync='checks') v-for {{indexId(n)}}
+  mdl-checkbox(v-if='disabled' id='v-if' type="checkbox" v-model='check' v-bind:disabled='disabled') v-if
+  mdl-checkbox(v-for='n in 3' v-bind:value='indexId(n)' v-bind:id='indexId(n)' type="checkbox" v-model='checks') v-for {{indexId(n)}}
   p#checks {{checks}}
 </template>
 

--- a/test/components/Checkbox.vue
+++ b/test/components/Checkbox.vue
@@ -10,15 +10,15 @@ div
     span.mdl-checkbox__label No ripple
   h3 vue
   // We can also use the jade syntax #id for literal ids
-  mdl-checkbox.added-class(id='check-dyn' type="checkbox" v-model='check') Dynamic {{check}}
-  mdl-checkbox#check(type="checkbox" v-model='check' v-bind:disabled='disabled') Check me
-  mdl-checkbox#number(type="checkbox" v-model='numCheck') My value is a number
+  mdl-checkbox.added-class(id='check-dyn' v-model='check') Dynamic {{check}}
+  mdl-checkbox#check(v-model='check' v-bind:disabled='disabled') Check me
+  mdl-checkbox#number(v-model='numCheck') My value is a number
   input#classic(type='checkbox' v-model='check')
   span Classic checkbox
   input#disable(type='checkbox' v-model='disabled')
   span Disable
-  mdl-checkbox(v-if='disabled' id='v-if' type="checkbox" v-model='check' v-bind:disabled='disabled') v-if
-  mdl-checkbox(v-for='(label, n) in 3' v-bind:value='indexId(n)' v-bind:id='indexId(n)' type="checkbox" v-model='checks') v-for {{indexId(n)}}
+  mdl-checkbox(v-if='disabled' id='v-if' v-model='check' v-bind:disabled='disabled') v-if
+  mdl-checkbox(v-for='(label, n) in 3' v-bind:checkValue='indexId(n)' v-bind:id='indexId(n)' v-model='checks') v-for {{indexId(n)}}
   p#checks {{checks}}
 </template>
 

--- a/test/components/Checkbox.vue
+++ b/test/components/Checkbox.vue
@@ -18,7 +18,7 @@ div
   input#disable(type='checkbox' v-model='disabled')
   span Disable
   mdl-checkbox(v-if='disabled' id='v-if' type="checkbox" v-model='check' v-bind:disabled='disabled') v-if
-  mdl-checkbox(v-for='n in 3' v-bind:value='indexId(n)' v-bind:id='indexId(n)' type="checkbox" v-model='checks') v-for {{indexId(n)}}
+  mdl-checkbox(v-for='(label, n) in 3' v-bind:value='indexId(n)' v-bind:id='indexId(n)' type="checkbox" v-model='checks') v-for {{indexId(n)}}
   p#checks {{checks}}
 </template>
 

--- a/test/components/Dialog.vue
+++ b/test/components/Dialog.vue
@@ -4,28 +4,28 @@ div
   br
   p Value is {{number}}
   #dialog
-    mdl-button(fab, primary, v-on:click='open("info")')
+    mdl-button(fab, primary, v-on:click.native="open('info')")
       i.material-icons info
-    mdl-button(fab, primary, v-on:click='open("multiple")')
+    mdl-button(fab, primary, v-on:click.native="open('multiple')")
       i.material-icons more
-    mdl-button(fab, primary, v-on:click='open("select")')
+    mdl-button(fab, primary, v-on:click.native="open('select')")
       i.material-icons language
 
     div
       p Events
       ul
-        li(v-for='event in events' track-by='$index') {{ event }}
+        li(v-for='(event, index) in events' v-bind:key='index') {{ event }}
 
-    mdl-dialog#info(v-ref:info v-on:close='closed' v-on:open='opened' title='Info message')
+    mdl-dialog#info(ref='info' v-on:close='closed' v-on:open='opened' title='Info message')
       p This is a modal example
 
-    mdl-dialog#multiple(v-ref:multiple title='Multiple Actions' display-on='multipleActionsMessage' full-width)
+    mdl-dialog#multiple(ref='multiple' title='Multiple Actions' display-on='multipleActionsMessage' full-width)
       p You can specify multiple Actions
       template(slot='actions')
-        mdl-button.mdl-js-ripple-effect(@click='number++' primary colored) Increase
-        mdl-button.mdl-js-ripple-effect(@click='number--' colored) Decrease
-        mdl-button.mdl-js-ripple-effect(@click='$refs.multiple.close') Close
-    mdl-dialog(v-ref:select title='Language')
+        mdl-button.mdl-js-ripple-effect(@click.native='number++' primary colored) Increase
+        mdl-button.mdl-js-ripple-effect(@click.native='number--' colored) Decrease
+        mdl-button.mdl-js-ripple-effect(@click.native="close('multiple')") Close
+    mdl-dialog(ref='select' title='Language')
       mdl-select#langs(label='Language', :value.sync='lang', :options='langs')
 </template>
 
@@ -65,6 +65,9 @@ export default {
     },
     open (ref) {
       this.$refs[ref].open()
+    },
+    close (ref) {
+      this.$refs[ref].close()
     }
   }
 }

--- a/test/components/IconToggle.vue
+++ b/test/components/IconToggle.vue
@@ -22,7 +22,7 @@ div
   span Disable
   mdl-icon-toggle(v-if='disabled' icon='face' id='v-if' v-bind:checked.sync='check' v-bind:disabled='disabled')
   mdl-icon-toggle(v-for='n in 3' icon='face' v-bind:value='indexId(n)' v-bind:id='indexId(n)' v-bind:checked.sync='checks')
-  p#its {{checks | json}}
+  p#its {{checks}}
 </template>
 
 <script lang="babel">

--- a/test/components/IconToggle.vue
+++ b/test/components/IconToggle.vue
@@ -13,15 +13,15 @@ div
     i.mdl-icon-toggle__label.material-icons http
   h3 vue
   // We can also use the jade syntax #id for literal ids
-  mdl-icon-toggle.added-class(id='it' icon='face' type="checkbox" v-model='check' v-bind:disabled='disabled')
-  mdl-icon-toggle(id='dit' v-bind:icon='icon' type="checkbox" v-model='check')
+  mdl-icon-toggle.added-class(id='it' icon='face' v-model='check' v-bind:disabled='disabled')
+  mdl-icon-toggle(id='dit' v-bind:icon='icon' v-model='check')
   input#dit-val(type='text' v-model='icon')
   input#classic(type='checkbox' v-model='check')
   span Classic icon-toggle
   input#disable(type='checkbox' v-model='disabled')
   span Disable
-  mdl-icon-toggle(v-if='disabled' icon='face' id='v-if' type="checkbox" v-model='check' v-bind:disabled='disabled')
-  mdl-icon-toggle(v-for='(label, n) in 3' icon='face' v-bind:value.once='indexId(n)' v-bind:id.once='indexId(n)' type="checkbox" v-model='checks')
+  mdl-icon-toggle(v-if='disabled' icon='face' id='v-if' v-model='check' v-bind:disabled='disabled')
+  mdl-icon-toggle(v-for='(label, n) in 3' icon='face' v-bind:checkValue.once='indexId(n)' v-bind:id.once='indexId(n)' v-model='checks')
   p#its {{checks}}
 </template>
 

--- a/test/components/IconToggle.vue
+++ b/test/components/IconToggle.vue
@@ -21,7 +21,7 @@ div
   input#disable(type='checkbox' v-model='disabled')
   span Disable
   mdl-icon-toggle(v-if='disabled' icon='face' id='v-if' type="checkbox" v-model='check' v-bind:disabled='disabled')
-  mdl-icon-toggle(v-for='n in 3' icon='face' v-bind:value.once='indexId(n)' v-bind:id.once='indexId(n)' type="checkbox" v-model='checks')
+  mdl-icon-toggle(v-for='(label, n) in 3' icon='face' v-bind:value.once='indexId(n)' v-bind:id.once='indexId(n)' type="checkbox" v-model='checks')
   p#its {{checks}}
 </template>
 

--- a/test/components/IconToggle.vue
+++ b/test/components/IconToggle.vue
@@ -13,15 +13,15 @@ div
     i.mdl-icon-toggle__label.material-icons http
   h3 vue
   // We can also use the jade syntax #id for literal ids
-  mdl-icon-toggle.added-class(id='it' icon='face' v-bind:checked.sync='check' v-bind:disabled='disabled')
-  mdl-icon-toggle(id='dit' v-bind:icon='icon' v-bind:checked.sync='check')
+  mdl-icon-toggle.added-class(id='it' icon='face' type="checkbox" v-model='check' v-bind:disabled='disabled')
+  mdl-icon-toggle(id='dit' v-bind:icon='icon' type="checkbox" v-model='check')
   input#dit-val(type='text' v-model='icon')
   input#classic(type='checkbox' v-model='check')
   span Classic icon-toggle
   input#disable(type='checkbox' v-model='disabled')
   span Disable
-  mdl-icon-toggle(v-if='disabled' icon='face' id='v-if' v-bind:checked.sync='check' v-bind:disabled='disabled')
-  mdl-icon-toggle(v-for='n in 3' icon='face' v-bind:value='indexId(n)' v-bind:id='indexId(n)' v-bind:checked.sync='checks')
+  mdl-icon-toggle(v-if='disabled' icon='face' id='v-if' type="checkbox" v-model='check' v-bind:disabled='disabled')
+  mdl-icon-toggle(v-for='n in 3' icon='face' v-bind:value.once='indexId(n)' v-bind:id.once='indexId(n)' type="checkbox" v-model='checks')
   p#its {{checks}}
 </template>
 

--- a/test/components/Menu.vue
+++ b/test/components/Menu.vue
@@ -50,9 +50,9 @@
           i.material-icons mood
           | Send Feedback
   mdl-button.mdl-js-ripple-effect(raised colored v-on:click.native='open') Open the menu
-  mdl-checkbox(v-model='group') Show Group
-  mdl-checkbox(v-model='show') Show Menu
-  mdl-checkbox(v-model='showButton') Show Button
+  mdl-checkbox(type="checkbox" v-model='group') Show Group
+  mdl-checkbox(type="checkbox" v-model='show') Show Menu
+  mdl-checkbox(type="checkbox" v-model='showButton') Show Button
   mdl-textfield(v-model='newOption', floating-label='New Option')
   mdl-button.mdl-js-ripple-effect(raised colored v-on:click.native='addOption') Add Option
 </template>

--- a/test/components/Menu.vue
+++ b/test/components/Menu.vue
@@ -75,7 +75,7 @@ export default {
   },
   methods: {
     open () {
-      this.$els.menu.MaterialMenu.handleForClick_()
+      this.$refs.menu.MaterialMenu.handleForClick_()
     },
     addOption () {
       this.options.push(this.newOption)

--- a/test/components/Menu.vue
+++ b/test/components/Menu.vue
@@ -43,18 +43,18 @@
     .bar(v-if='group')
       button#v-menu.mdl-button.mdl-js-button.mdl-button--icon(v-if='showButton')
         i.material-icons more_vert
-      mdl-menu(v-if='show' for='v-menu' v-el:menu)
+      mdl-menu(v-if='show' target='v-menu' ref='menu')
         mdl-menu-item Hello
-        mdl-menu-item(v-for='option in options' track-by='$index' v-bind:disabled='$index === 2') {{option}}
+        mdl-menu-item(v-for='(option, index) in options' v-bind:key='index' v-bind:disabled='index === 2') {{option}}
         li.mdl-menu__item
           i.material-icons mood
           | Send Feedback
-  mdl-button.mdl-js-ripple-effect(raised colored @click='open') Open the menu
-  mdl-checkbox(:checked.sync='group') Show Group
-  mdl-checkbox(:checked.sync='show') Show Menu
-  mdl-checkbox(:checked.sync='showButton') Show Button
-  mdl-textfield(:value='newOption', floating-label='New Option')
-  mdl-button.mdl-js-ripple-effect(raised colored @click='addOption') Add Option
+  mdl-button.mdl-js-ripple-effect(raised colored v-on:click.native='open') Open the menu
+  mdl-checkbox(v-model='group') Show Group
+  mdl-checkbox(v-model='show') Show Menu
+  mdl-checkbox(v-model='showButton') Show Button
+  mdl-textfield(v-model='newOption', floating-label='New Option')
+  mdl-button.mdl-js-ripple-effect(raised colored v-on:click.native='addOption') Add Option
 </template>
 
 <script lang="babel">

--- a/test/components/Radio.vue
+++ b/test/components/Radio.vue
@@ -9,17 +9,17 @@ div
     input#option-2.mdl-radio__button(type='radio', name='options', value='2')
     span.mdl-radio__label Second
   h3 vue
-  mdl-radio.added-class(v-model='fruit' id='banana' value='Banana') Banana
-  mdl-radio(v-model='fruit' id='pineapple' value='Pineapple') Pineapple
-  mdl-radio(v-model='fruit' id='kiwi' value='Kiwi') Kiwi
+  mdl-radio.added-class(type="radio" v-model='fruit' id='banana' value='Banana') Banana
+  mdl-radio(type="radio" v-model='fruit' id='pineapple' value='Pineapple') Pineapple
+  mdl-radio(type="radio" v-model='fruit' id='kiwi' value='Kiwi') Kiwi
   br
   p#text {{size}} {{fruit}}
-  mdl-radio(v-modelc='size' id='extra' value='Extra' v-if='disabled') Extra
-  mdl-radio(v-model='size' id='big' value='Big' v-bind:disabled='disabled') Big
-  mdl-radio(v-model='size' id='medium' value='Medium') Medium
-  mdl-radio(v-model='size' id='little' value='Little') Little
+  mdl-radio(type="radio" v-model='size' id='extra' value='Extra' v-if='disabled') Extra
+  mdl-radio(type="radio" v-model='size' id='big' value='Big' v-bind:disabled='disabled') Big
+  mdl-radio(type="radio" v-model='size' id='medium' value='Medium') Medium
+  mdl-radio(type="radio" v-model='size' id='little' value='Little') Little
   br
-  <mdl-radio v-model='size' id='html-radio' value='HTML' disabled>HTML</mdl-radio>
+  <mdl-radio type='radio' v-model='size' id='html-radio' value='HTML' disabled>HTML</mdl-radio>
   input#disable(type='checkbox' v-bind:disabled='disabled')
   span Disable Big
   br

--- a/test/components/Radio.vue
+++ b/test/components/Radio.vue
@@ -9,18 +9,18 @@ div
     input#option-2.mdl-radio__button(type='radio', name='options', value='2')
     span.mdl-radio__label Second
   h3 vue
-  mdl-radio.added-class(v-bind:checked.sync='fruit' id='banana' value='Banana') Banana
-  mdl-radio(v-bind:checked.sync='fruit' id='pineapple' value='Pineapple') Pineapple
-  mdl-radio(v-bind:checked.sync='fruit' id='kiwi' value='Kiwi') Kiwi
+  mdl-radio.added-class(v-model='fruit' id='banana' value='Banana') Banana
+  mdl-radio(v-model='fruit' id='pineapple' value='Pineapple') Pineapple
+  mdl-radio(v-model='fruit' id='kiwi' value='Kiwi') Kiwi
   br
   p#text {{size}} {{fruit}}
-  mdl-radio(v-bind:checked.sync='size' id='extra' value='Extra' v-if='disabled') Extra
-  mdl-radio(v-bind:checked.sync='size' id='big' value='Big' v-bind:disabled='disabled') Big
-  mdl-radio(v-bind:checked.sync='size' id='medium' value='Medium') Medium
-  mdl-radio(v-bind:checked.sync='size' id='little' value='Little') Little
+  mdl-radio(v-modelc='size' id='extra' value='Extra' v-if='disabled') Extra
+  mdl-radio(v-model='size' id='big' value='Big' v-bind:disabled='disabled') Big
+  mdl-radio(v-model='size' id='medium' value='Medium') Medium
+  mdl-radio(v-model='size' id='little' value='Little') Little
   br
-  <mdl-radio v-bind:checked.sync='size' id='html-radio' value='HTML' disabled>HTML</mdl-radio>
-  input#disable(type='checkbox' v-model='disabled')
+  <mdl-radio v-model='size' id='html-radio' value='HTML' disabled>HTML</mdl-radio>
+  input#disable(type='checkbox' v-bind:disabled='disabled')
   span Disable Big
   br
   input(v-model='size' type="radio" id='big-or' value='Big')

--- a/test/components/Radio.vue
+++ b/test/components/Radio.vue
@@ -9,17 +9,17 @@ div
     input#option-2.mdl-radio__button(type='radio', name='options', value='2')
     span.mdl-radio__label Second
   h3 vue
-  mdl-radio.added-class(type="radio" v-model='fruit' id='banana' value='Banana') Banana
-  mdl-radio(type="radio" v-model='fruit' id='pineapple' value='Pineapple') Pineapple
-  mdl-radio(type="radio" v-model='fruit' id='kiwi' value='Kiwi') Kiwi
+  mdl-radio.added-class(v-model='fruit' id='banana' radio-value='Banana') Banana
+  mdl-radio(v-model='fruit' id='pineapple' radio-value='Pineapple') Pineapple
+  mdl-radio(v-model='fruit' id='kiwi' radio-value='Kiwi') Kiwi
   br
   p#text {{size}} {{fruit}}
-  mdl-radio(type="radio" v-model='size' id='extra' value='Extra' v-if='disabled') Extra
-  mdl-radio(type="radio" v-model='size' id='big' value='Big' v-bind:disabled='disabled') Big
-  mdl-radio(type="radio" v-model='size' id='medium' value='Medium') Medium
-  mdl-radio(type="radio" v-model='size' id='little' value='Little') Little
+  mdl-radio(v-model='size' id='extra' radio-value='Extra' v-if='disabled') Extra
+  mdl-radio(v-model='size' id='big' radio-value='Big' v-bind:disabled='disabled') Big
+  mdl-radio(v-model='size' id='medium' radio-value='Medium') Medium
+  mdl-radio(v-model='size' id='little' radio-value='Little') Little
   br
-  <mdl-radio type='radio' v-model='size' id='html-radio' value='HTML' disabled>HTML</mdl-radio>
+  <mdl-radio v-model='size' id='html-radio' radio-value='HTML' disabled>HTML</mdl-radio>
   input#disable(type='checkbox' v-bind:disabled='disabled')
   span Disable Big
   br

--- a/test/components/Radio.vue
+++ b/test/components/Radio.vue
@@ -9,17 +9,17 @@ div
     input#option-2.mdl-radio__button(type='radio', name='options', value='2')
     span.mdl-radio__label Second
   h3 vue
-  mdl-radio.added-class(v-model='fruit' id='banana' radio-value='Banana') Banana
-  mdl-radio(v-model='fruit' id='pineapple' radio-value='Pineapple') Pineapple
-  mdl-radio(v-model='fruit' id='kiwi' radio-value='Kiwi') Kiwi
+  mdl-radio.added-class(v-model='fruit' id='banana' selected-value='Banana') Banana
+  mdl-radio(v-model='fruit' id='pineapple' selected-value='Pineapple') Pineapple
+  mdl-radio(v-model='fruit' id='kiwi' selected-value='Kiwi') Kiwi
   br
   p#text {{size}} {{fruit}}
-  mdl-radio(v-model='size' id='extra' radio-value='Extra' v-if='disabled') Extra
-  mdl-radio(v-model='size' id='big' radio-value='Big' v-bind:disabled='disabled') Big
-  mdl-radio(v-model='size' id='medium' radio-value='Medium') Medium
-  mdl-radio(v-model='size' id='little' radio-value='Little') Little
+  mdl-radio(v-model='size' id='extra' selected-value='Extra' v-if='disabled') Extra
+  mdl-radio(v-model='size' id='big' selected-value='Big' v-bind:disabled='disabled') Big
+  mdl-radio(v-model='size' id='medium' selected-value='Medium') Medium
+  mdl-radio(v-model='size' id='little' selected-value='Little') Little
   br
-  <mdl-radio v-model='size' id='html-radio' radio-value='HTML' disabled>HTML</mdl-radio>
+  <mdl-radio v-model='size' id='html-radio' selected-value='HTML' disabled>HTML</mdl-radio>
   input#disable(type='checkbox' v-bind:disabled='disabled')
   span Disable Big
   br

--- a/test/components/Ripple-effect.vue
+++ b/test/components/Ripple-effect.vue
@@ -3,10 +3,10 @@ div
   h1 Ripple Effect
   h3 vue
   mdl-button#button-ripple(mdl-ripple-effect) Hello
-  mdl-checkbox#checkbox-ripple(mdl-ripple-effect type="checkbox" v-model='check') Checkbox
-  mdl-radio#radio-ripple(mdl-ripple-effect value='one' type="radio" v-model='check') Radio
-  mdl-switch#switch-ripple(mdl-ripple-effect type="checkbox" v-model='check')
-  mdl-icon-toggle#icon-toggle-ripple(mdl-ripple-effect type="checkbox" v-model='check' icon='add')
+  mdl-checkbox#checkbox-ripple(mdl-ripple-effect v-model='check') Checkbox
+  mdl-radio#radio-ripple(mdl-ripple-effect selected-value='one' v-model='check') Radio
+  mdl-switch#switch-ripple(mdl-ripple-effect v-model='check')
+  mdl-icon-toggle#icon-toggle-ripple(mdl-ripple-effect v-model='check' icon='add')
 </template>
 
 <script lang="babel">

--- a/test/components/Ripple-effect.vue
+++ b/test/components/Ripple-effect.vue
@@ -2,11 +2,11 @@
 div
   h1 Ripple Effect
   h3 vue
-  mdl-button#button-ripple(v-mdl-ripple-effect) Hello
-  mdl-checkbox#checkbox-ripple(v-mdl-ripple-effect v-bind:checked.sync='check') Checkbox
-  mdl-radio#radio-ripple(v-mdl-ripple-effect value='one' v-bind:checked.sync='check') Radio
-  mdl-switch#switch-ripple(v-mdl-ripple-effect v-bind:checked.sync='check')
-  mdl-icon-toggle#icon-toggle-ripple(v-mdl-ripple-effect v-bind:checked.sync='check' icon='add')
+  mdl-button#button-ripple(mdl-ripple-effect) Hello
+  mdl-checkbox#checkbox-ripple(mdl-ripple-effect type="checkbox" v-model='check') Checkbox
+  mdl-radio#radio-ripple(mdl-ripple-effect value='one' type="radio" v-model='check') Radio
+  mdl-switch#switch-ripple(mdl-ripple-effect type="checkbox" v-model='check')
+  mdl-icon-toggle#icon-toggle-ripple(mdl-ripple-effect type="checkbox" v-model='check' icon='add')
 </template>
 
 <script lang="babel">

--- a/test/components/Select.vue
+++ b/test/components/Select.vue
@@ -2,11 +2,11 @@
 div
   h1 Select
   h3 vue
-  mdl-checkbox(:checked.sync='visible') Visible
-  p Changed {{changes}}
-  mdl-select#select(v-if='visible', label='Country', @change='changes++', :value.sync='country', :options='countriesArray')
-  br
-  mdl-select#select-val(ref='selectVal' label='Country', :value.sync='countryVal', :options='countries')
+  mdl-checkbox(type="checkbox" v-model='visible') Visible
+  p Country {{country}}
+  mdl-select#select(v-if='visible', label='Country', v-model='country', :options='countriesArray')
+  p Country Val {{countryVal}}
+  mdl-select#select-val(ref='selectVal' label='Country', v-model='countryVal', :options='countries')
 </template>
 
 <script lang="babel">

--- a/test/components/Select.vue
+++ b/test/components/Select.vue
@@ -6,7 +6,7 @@ div
   p Changed {{changes}}
   mdl-select#select(v-if='visible', label='Country', @change='changes++', :value.sync='country', :options='countriesArray')
   br
-  mdl-select#select-val(v-ref:select-val label='Country', :value.sync='countryVal', :options='countries')
+  mdl-select#select-val(ref='selectVal' label='Country', :value.sync='countryVal', :options='countries')
 </template>
 
 <script lang="babel">

--- a/test/components/Snackbar.vue
+++ b/test/components/Snackbar.vue
@@ -1,29 +1,30 @@
 <template lang="jade">
 div
   h1 Snackbar
-  mdl-snackbar#snackbar(ref='snackbar')
+  mdl-snackbar#snackbar(display-on='sendMail')
+  mdl-snackbar#source(display-on='sendMail', :event-source="bus")
   mdl-button(@click.native='sendMail') Send
 </template>
 
 <script lang="babel">
+import Vue from 'vue'
+
 export default {
   data () {
     return {
+      bus: new Vue()
     }
   },
   methods: {
-    showSnackbar ({message, actionText}) {
-      this.$refs.snackbar.showSnackbar({
-        message: message,
+    sendMail () {
+      this.$root.$emit('sendMail', {
+        message: 'Message Sent',
         actionHandler: (event) => {
           // Stuff to do when the action is clicked
         },
-        actionText: actionText,
+        actionText: 'Undo',
         timeout: 1000
       })
-    },
-    sendMail () {
-      this.showSnackbar({ message: 'Message Sent', actionText: 'Undo' })
     }
   }
 }

--- a/test/components/Snackbar.vue
+++ b/test/components/Snackbar.vue
@@ -1,8 +1,8 @@
 <template lang="jade">
 div
   h1 Snackbar
-  mdl-snackbar#snackbar(display-on='mailSent')
-  mdl-button(@click='sendMail') Send
+  mdl-snackbar#snackbar(ref='snackbar')
+  mdl-button(@click.native='sendMail') Send
 </template>
 
 <script lang="babel">
@@ -12,15 +12,18 @@ export default {
     }
   },
   methods: {
-    sendMail () {
-      this.$broadcast('mailSent', {
-        message: 'Message Sent',
+    showSnackbar ({message, actionText}) {
+      this.$refs.snackbar.showSnackbar({
+        message: message,
         actionHandler: (event) => {
           // Stuff to do when the action is clicked
         },
-        actionText: 'Undo',
+        actionText: actionText,
         timeout: 1000
       })
+    },
+    sendMail () {
+      this.showSnackbar({ message: 'Message Sent', actionText: 'Undo' })
     }
   }
 }

--- a/test/components/Switch.vue
+++ b/test/components/Switch.vue
@@ -18,7 +18,7 @@ div
     input#disable(type='checkbox' v-model='disabled')
     span Disable
   mdl-switch(v-if='disabled' id='v-if' type="checkbox" v-model='check' v-bind:disabled='disabled') v-if
-  mdl-switch(v-for='n in 3' v-bind:value='indexId(n)' v-bind:id='indexId(n)' type="checkbox" v-model='checks') v-for {{indexId(n)}}
+  mdl-switch(v-for='(label, n) in 3' v-bind:value='indexId(n)' v-bind:id='indexId(n)' type="checkbox" v-model='checks') v-for {{indexId(n)}}
   p#checks {{checks}}
 </template>
 

--- a/test/components/Switch.vue
+++ b/test/components/Switch.vue
@@ -19,7 +19,7 @@ div
     span Disable
   mdl-switch(v-if='disabled' id='v-if' v-bind:checked.sync='check' v-bind:disabled='disabled') v-if
   mdl-switch(v-for='n in 3' v-bind:value='indexId(n)' v-bind:id='indexId(n)' v-bind:checked.sync='checks') v-for {{indexId(n)}}
-  p#checks {{checks | json}}
+  p#checks {{checks}}
 </template>
 
 <script lang="babel">

--- a/test/components/Switch.vue
+++ b/test/components/Switch.vue
@@ -10,15 +10,15 @@ div
     span.mdl-switch__label No ripple
   h3 vue
   p
-    mdl-switch.added-class(id='check-dyn' v-bind:checked.sync='check') Dynamic {{check}}
-    mdl-switch(id='check' v-bind:checked.sync='check' v-bind:disabled='disabled') Check me
+    mdl-switch.added-class(id='check-dyn' type="checkbox" v-model='check') Dynamic {{check}}
+    mdl-switch(id='check' type="checkbox" v-model='check' v-bind:disabled='disabled') Check me
   p
     input#classic(type='checkbox' v-model='check')
     span Classic checkbox
     input#disable(type='checkbox' v-model='disabled')
     span Disable
-  mdl-switch(v-if='disabled' id='v-if' v-bind:checked.sync='check' v-bind:disabled='disabled') v-if
-  mdl-switch(v-for='n in 3' v-bind:value='indexId(n)' v-bind:id='indexId(n)' v-bind:checked.sync='checks') v-for {{indexId(n)}}
+  mdl-switch(v-if='disabled' id='v-if' type="checkbox" v-model='check' v-bind:disabled='disabled') v-if
+  mdl-switch(v-for='n in 3' v-bind:value='indexId(n)' v-bind:id='indexId(n)' type="checkbox" v-model='checks') v-for {{indexId(n)}}
   p#checks {{checks}}
 </template>
 

--- a/test/components/Switch.vue
+++ b/test/components/Switch.vue
@@ -10,15 +10,15 @@ div
     span.mdl-switch__label No ripple
   h3 vue
   p
-    mdl-switch.added-class(id='check-dyn' type="checkbox" v-model='check') Dynamic {{check}}
-    mdl-switch(id='check' type="checkbox" v-model='check' v-bind:disabled='disabled') Check me
+    mdl-switch.added-class(id='check-dyn' v-model='check') Dynamic {{check}}
+    mdl-switch(id='check' v-model='check' v-bind:disabled='disabled') Check me
   p
     input#classic(type='checkbox' v-model='check')
     span Classic checkbox
     input#disable(type='checkbox' v-model='disabled')
     span Disable
-  mdl-switch(v-if='disabled' id='v-if' type="checkbox" v-model='check' v-bind:disabled='disabled') v-if
-  mdl-switch(v-for='(label, n) in 3' v-bind:value='indexId(n)' v-bind:id='indexId(n)' type="checkbox" v-model='checks') v-for {{indexId(n)}}
+  mdl-switch(v-if='disabled' id='v-if' v-model='check' v-bind:disabled='disabled') v-if
+  mdl-switch(v-for='(label, n) in 3' v-bind:checkValue='indexId(n)' v-bind:id='indexId(n)' v-model='checks') v-for {{indexId(n)}}
   p#checks {{checks}}
 </template>
 

--- a/test/components/Tabs.vue
+++ b/test/components/Tabs.vue
@@ -2,7 +2,7 @@
   <div>
     <h1>Tabs</h1>
 
-    <mdl-tabs :no-ripple-effect="!ripples" id="tabs" :selected.sync="selected">
+    <mdl-tabs :no-ripple-effect="!ripples" id="tabs" v-model="selected">
       <mdl-tab tab="Tab 1">
         Tab 1
       </mdl-tab>
@@ -13,17 +13,17 @@
         Tab 3
       </mdl-tab>
       <mdl-tab
-          v-for="tab in tabs"
-          track-by="$index"
+          v-for="(tab, index) in tabs"
+          :key="index"
           :tab="tab"
       >
     </mdl-tabs>
 
-    <mdl-tabs id="dyn-tabs" v-ref:tabs :selected.sync="selected">
+    <mdl-tabs id="dyn-tabs" ref="tabs" v-model="selected">
       <mdl-tab
-          v-for="tab in dynTabs"
-          track-by="$index"
-          :tab="{title: tab, id: $index}"
+          v-for="(tab, index) in dynTabs"
+          :key="index"
+          :tab="{title: tab, id: index}"
       >
         {{tab}}
       </mdl-tab>
@@ -32,10 +32,10 @@
     <br>
     <br>
 
-    <button @click="addTab">Add Tab</button>
-    <div v-for="tab in dynTabs" track-by="$index">
+    <button @click.native="addTab">Add Tab</button>
+    <div v-for="(tab, index) in dynTabs" :key="index">
       <span>{{tab}}</span>
-      <button @click="removeTab($index)">X</button>
+      <button @click.native="removeTab(index)">X</button>
     </div>
     <input type="checkbox" v-model="ripples"> Ripples
   </div>

--- a/test/components/Textfield.vue
+++ b/test/components/Textfield.vue
@@ -47,7 +47,7 @@ div
   br
   p {{text}}
   p {{testme}}
-  mdl-checkbox(v-model='float') Float
+  mdl-checkbox(type="checkbox" v-model='float') Float
   <mdl-textfield v-model='requiredValue' id='required' floating-label='Required' required></mdl-textfield>
   <mdl-textfield v-model='requiredValue' id='required-textarea' floating-label='Required' required textarea></mdl-textfield>
   mdl-textfield#maxlength-input(v-model='requiredValue', :maxlength='maxlength', floating-label="Maxlength")

--- a/test/components/Textfield.vue
+++ b/test/components/Textfield.vue
@@ -2,7 +2,7 @@
 div
   h1 Textfield
   h3 MDL
-  .mdl(v-mdl)
+  .mdl(mdl)
     .mdl-textfield.mdl-js-textfield
       input#sample1.mdl-textfield__input(type='text')
       label.mdl-textfield__label(for='sample1') Text...
@@ -24,13 +24,13 @@ div
       input#sample6.mdl-textfield__input(type='text')
       label.mdl-textfield__label(for='sample6') Expandable Input
   h3 vue
-  mdl-textfield#testme(@change='test' v-on:keyup.left='test(rows, $event)', :value.sync='testme' floating-label="TEST ME")
+  mdl-textfield#testme(@change='test' v-on:keyup.left='test(rows, $event)', v-model='testme' floating-label="TEST ME")
   mdl-textfield#fly(label='I fly' floating-label)
   mdl-textfield#fly2(floating-label='I fly')
   mdl-textfield#fly-label-dyn(:floating-label='dynFloat')
-  mdl-textfield.added-class#classic(label='Classic', :type='type', :value.sync='text')
+  mdl-textfield.added-class#classic(label='Classic', :type='type', v-model='text')
   mdl-textfield#fly-dyn(label='Dynamic fly' v-bind:floating-label='float' v-bind:label='label')
-  mdl-textfield#textarea(label='textarea', textarea, :rows='rows', :value.sync='multiText')
+  mdl-textfield#textarea(label='textarea', textarea, :rows='rows', v-model='multiText')
   pre#multi-text {{multiText}}
   <mdl-textfield id='html-text' label='textarea' textarea></mdl-textfield>
   mdl-textfield#number(label='Number', :pattern='pattern', floating-label, :error='error')
@@ -43,19 +43,19 @@ div
       span That's not a number
   mdl-textfield#custom-area(floating-label textarea)
     textarea#custom-area(slot='textarea' type='text')
-  mdl-textfield#expandable(floating-label v-bind:value.sync='text' expandable='search' label='Search')
+  mdl-textfield#expandable(floating-label v-model='text' expandable='search' label='Search')
   br
   p {{text}}
-  mdl-checkbox(:checked.sync='float') Float
-  <mdl-textfield :value.sync='requiredValue' id='required' floating-label='Required' required></mdl-textfield>
-  <mdl-textfield :value.sync='requiredValue' id='required-textarea' floating-label='Required' required textarea></mdl-textfield>
-  mdl-textfield#maxlength-input(:value.sync='requiredValue', :maxlength='maxlength', floating-label="Maxlength")
-  mdl-textfield#maxlength-textarea(:value.sync='requiredValue', :maxlength='maxlength', floating-label="Maxlength" textarea)
+  p {{testme}}
+  mdl-checkbox(v-model='float') Float
+  <mdl-textfield v-model='requiredValue' id='required' floating-label='Required' required></mdl-textfield>
+  <mdl-textfield v-model='requiredValue' id='required-textarea' floating-label='Required' required textarea></mdl-textfield>
+  mdl-textfield#maxlength-input(v-model='requiredValue', :maxlength='maxlength', floating-label="Maxlength")
+  mdl-textfield#maxlength-textarea(v-model='requiredValue', :maxlength='maxlength', floating-label="Maxlength" textarea)
   mdl-textfield#disabled-input(:value.sync='text', disabled, floating-label="Disabled")
   mdl-textfield#disabled-textarea(:value.sync='text', disabled, floating-label="Disabled" textarea)
   mdl-textfield#readonly-input(:value.sync='text', readonly, floating-label="Disabled")
   mdl-textfield#readonly-textarea(:value.sync='text', readonly, floating-label="Disabled" textarea)
-
 </template>
 
 <script lang="babel">

--- a/test/components/Tooltip.vue
+++ b/test/components/Tooltip.vue
@@ -2,7 +2,7 @@
 div
   h1 Tooltip
   h3 MDL
-  div(v-mdl)
+  div(mdl)
     .icon.material-icons#tt1 add
     .mdl-tooltip(for='tt1')
       p Follow
@@ -11,12 +11,12 @@ div
       | Print
   h3 vue
   i.material-icons#tooltip add
-  mdl-tooltip(v-bind:class='{hoho: active}' for='tooltip') Add something
+  mdl-tooltip(v-bind:class='{hoho: active}' target='tooltip') Add something
   i.material-icons#large print
-  mdl-tooltip.added-class(for='large' large) Print
-  <mdl-tooltip for='html' large>Print</mdl-tooltip>
+  mdl-tooltip.added-class(target='large' large) Print
+  <mdl-tooltip target='html' large>Print</mdl-tooltip>
   mdl-spinner#spin
-  mdl-tooltip(for='spin')
+  mdl-tooltip(target='spin')
     p
       i.material-icons cached
       span It's still loading...

--- a/test/unit/index.html
+++ b/test/unit/index.html
@@ -11,7 +11,9 @@
 </head>
 
 <body>
-  <app :components="components"></app>
+  <div id="app">
+    <!--<app :components="components"></app>-->
+  </div>
   <!-- built files will be auto injected -->
 </body>
 

--- a/test/unit/main.js
+++ b/test/unit/main.js
@@ -17,7 +17,10 @@ context.keys().forEach((comp) => {
 
 /* eslint-disable no-new */
 new Vue({
-  el: 'body',
+  el: '#app',
+  render: function (h) {
+    return h('app', { props: { components: this.components } })
+  },
   data: {
     components
   },

--- a/test/unit/specs/Button.spec.js
+++ b/test/unit/specs/Button.spec.js
@@ -92,6 +92,7 @@ describe('Button', () => {
 
   it('applies classes even with empty strings in props', () => {
     let but = vm.$('#html-button')
+    console.log('html-button', but)
     but.should.have.class('mdl-button--raised')
     but.should.have.class('mdl-button--colored')
     but.should.not.have.class('mdl-button--accent')

--- a/test/unit/specs/Card.spec.js
+++ b/test/unit/specs/Card.spec.js
@@ -127,14 +127,14 @@ describe('Card', () => {
 
   it('dispatchs events for actions button', () => {
     const spy = sinon.spy()
-    vm.$once('increaseNum', spy)
+    vm.$refs.increaseCard.$once('increaseNum', spy)
     vm.$('#actions-button button').click()
     spy.should.have.been.calledOnce
   })
 
   it('dispatchs events for menu button', () => {
     const spy = sinon.spy()
-    vm.$once('cardMenu', spy)
+    vm.$refs.cardMenu.$once('cardMenu', spy)
     vm.$('#menu .mdl-card__menu button').click()
     spy.should.have.been.calledOnce
   })

--- a/test/unit/specs/Radio.spec.js
+++ b/test/unit/specs/Radio.spec.js
@@ -58,6 +58,8 @@ describe('Radio', () => {
     vm.disabled = true
     vm.nextTick()
     .then(() => {
+      big = vm.$('#big')
+      bigLabel = vm.$('label[for=big]')
       big.disabled.should.be.true
       big.should.have.attr('disabled')
       bigLabel.should.have.class('is-disabled')

--- a/test/unit/specs/Snackbar.spec.js
+++ b/test/unit/specs/Snackbar.spec.js
@@ -24,13 +24,8 @@ describe('Snackbar', () => {
     snackbar.querySelector('.mdl-snackbar__text').should.be.empty
   })
 
-  it('shows with an event', (done) => {
-    vm.$broadcast('mailSent', {
-      message: 'Test event',
-      actionText: 'Undo',
-      actionHandler (event) {},
-      timeout: 10
-    })
+  it('shows when invoked', (done) => {
+    vm.showSnackbar({ message: 'Test event', actionText: 'Undo' })
     vm.nextTick()
     .then(() => {
       snackbar.querySelector('.mdl-snackbar__text').should.have.text('Test event')

--- a/test/unit/specs/Snackbar.spec.js
+++ b/test/unit/specs/Snackbar.spec.js
@@ -3,10 +3,11 @@ import { vueTest } from '../utils'
 
 describe('Snackbar', () => {
   let vm
-  let snackbar
+  let snackbar, sourceSnackbar
   before(() => {
     vm = vueTest(Snackbar)
     snackbar = vm.$('#snackbar')
+    sourceSnackbar = vm.$('#source')
   })
 
   it('exists', () => {
@@ -24,12 +25,22 @@ describe('Snackbar', () => {
     snackbar.querySelector('.mdl-snackbar__text').should.be.empty
   })
 
-  it('shows when invoked', (done) => {
-    vm.showSnackbar({ message: 'Test event', actionText: 'Undo' })
+  it('shows the snackbar by emitting events on $root by default', (done) => {
+    vm.$root.$emit('sendMail', { message: 'Test event', actionText: 'Undo', actionHandler: (ev) => { }, timeout: 100 })
     vm.nextTick()
     .then(() => {
       snackbar.querySelector('.mdl-snackbar__text').should.have.text('Test event')
       snackbar.querySelector('.mdl-snackbar__action').should.have.text('Undo')
+      return vm.nextTick()
+    }).then(done, done)
+  })
+
+  it('shows the snackbar by emitting events on specified event source', (done) => {
+    vm.bus.$emit('sendMail', { message: 'Test event', actionText: 'Undo', actionHandler: (ev) => { }, timeout: 100 })
+    vm.nextTick()
+    .then(() => {
+      sourceSnackbar.querySelector('.mdl-snackbar__text').should.have.text('Test event')
+      sourceSnackbar.querySelector('.mdl-snackbar__action').should.have.text('Undo')
       return vm.nextTick()
     }).then(done, done)
   })

--- a/test/unit/specs/Tab.spec.js
+++ b/test/unit/specs/Tab.spec.js
@@ -139,7 +139,7 @@ describe('Tabs', () => {
       vm.selected = 'Tab 1'
       const tabs = getTabs(simple)
       tabs[1].click()
-      vm.selected.should.eql('Tab 2')
+      vm.selected.should.eql('Tab 2');
     })
   })
 

--- a/test/unit/specs/Tab.spec.js
+++ b/test/unit/specs/Tab.spec.js
@@ -139,7 +139,7 @@ describe('Tabs', () => {
       vm.selected = 'Tab 1'
       const tabs = getTabs(simple)
       tabs[1].click()
-      vm.selected.should.eql('Tab 2');
+      vm.selected.should.eql('Tab 2')
     })
   })
 

--- a/test/unit/specs/VueMdl.spec.js
+++ b/test/unit/specs/VueMdl.spec.js
@@ -10,7 +10,7 @@ import {
 describe('Register', () => {
   it('exports single components', () => {
     MdlCheckbox.should.exist.and.be.an.Object
-    MdlCheckbox.should.have.property('template')
+    MdlCheckbox.should.have.property('render')
   })
 
   it('exports single directives', () => {


### PR DESCRIPTION
Here is the work so far to support VueJS 2.0. A high level overview.
- The toggle/radio controls now all work with a combination of 'v-model' and 'selected-value' properties.
- Because of the event propagation changes for Vue 2.0, Snackbar can't receive events broadcast from an arbitrary instance, so we instead have an override-able 'event-source' property. It defaults to "this.$root" so the event can be emitted on $root from any component. If you want to use some global event bus instead, you can set it there.
- There are two failing tests for badge, since, AFAICT, we can't have arbitrary extra props for directives, which was how the "hide-badge' support currently works.

Thanks!
