### PR TITLE
Add .getmdl-select__fullwidth and .getmdl-select__fix-height classes

### DIFF
--- a/src/select.vue
+++ b/src/select.vue
@@ -93,19 +93,27 @@ export default {
 
 <style>
 .getmdl-select .mdl-icon-toggle__label {
-  float:right;
-  margin-top:-30px;
+  float: right;
+  margin-top: -30px;
   color: rgba(0, 0, 0, 0.4);
 }
-
 .getmdl-select.is-focused .mdl-icon-toggle__label {
   color: #3f51b5;
 }
-
 .getmdl-select .mdl-menu__container {
   width: 100% !important;
+  overflow: hidden;
 }
-.getmdl-select .mdl-menu__container .mdl-menu {
+.getmdl-select .mdl-menu__container .mdl-menu .mdl-menu__item {
+  font-size: 16px;
+}
+
+.getmdl-select__fullwidth, .mdl-menu {
   width: 100%;
+}
+
+.getmdl-select__fix-height .mdl-menu__container {
+  overflow-y: auto;
+  max-height: 300px !important;
 }
 </style>


### PR DESCRIPTION
Update the CSS of mdl-select according to https://github.com/CreativeIT/getmdl-select/blob/master/src/scss/getmdl-select.scss so that the element can automatically adapt to the maximum height and/or the maximum width of values.