### PR TITLE
Fix Tabs test : tag <mdl-tab> has no matching end tag

### DIFF
--- a/test/components/Tabs.vue
+++ b/test/components/Tabs.vue
@@ -17,6 +17,8 @@
           :key="index"
           :tab="tab"
       >
+        {{tab}}
+      </mdl-tab>
     </mdl-tabs>
 
     <mdl-tabs id="dyn-tabs" ref="tabs" v-model="selected">

--- a/test/components/Tabs.vue
+++ b/test/components/Tabs.vue
@@ -12,6 +12,13 @@
       <mdl-tab tab="Tab 3">
         Tab 3
       </mdl-tab>
+      <mdl-tab
+          v-for="(tab, index) in dynTabs"
+          :key="index"
+          :tab="{title: tab, id: index}"
+      >
+        {{tab}}
+      </mdl-tab>
     </mdl-tabs>
 
     <mdl-tabs id="dyn-tabs" ref="tabs" v-model="selected">

--- a/test/components/Tabs.vue
+++ b/test/components/Tabs.vue
@@ -12,13 +12,6 @@
       <mdl-tab tab="Tab 3">
         Tab 3
       </mdl-tab>
-      <mdl-tab
-          v-for="(tab, index) in tabs"
-          :key="index"
-          :tab="tab"
-      >
-        {{tab}}
-      </mdl-tab>
     </mdl-tabs>
 
     <mdl-tabs id="dyn-tabs" ref="tabs" v-model="selected">

--- a/test/components/Tabs.vue
+++ b/test/components/Tabs.vue
@@ -13,9 +13,9 @@
         Tab 3
       </mdl-tab>
       <mdl-tab
-          v-for="(tab, index) in dynTabs"
+          v-for="(tab, index) in tabs"
           :key="index"
-          :tab="{title: tab, id: index}"
+          :tab="tab"
       >
         {{tab}}
       </mdl-tab>


### PR DESCRIPTION
When i run `npm run dev' under windows, i have one error : **tag < mdl-tab > has no matching end tag**

```console
C:\Users\forresst\Lab\vue-mdl>npm run dev

> vue-mdl@1.1.1 dev C:\Users\forresst\Lab\vue-mdl
> karma start test/unit/karma.dev.conf.js

Hash: 27f6a60538ac5afe667b
Version: webpack 1.14.0
Time: 25581ms
   Asset     Size  Chunks             Chunk Names
index.js  1.95 MB       0  [emitted]  index.js
chunk    {0} index.js (index.js) 664 kB [rendered]
    [0] ./test/unit/index.js 638 bytes {0} [built]
    [1] ./~/vue/dist/vue.runtime.common.js 174 kB {0} [built]
    [2] ./~/process/browser.js 5.3 kB {0} [built]
    [3] ./src/vue-mdl.js 6.1 kB {0} [built]
    [4] ./~/babel-runtime/core-js/object/keys.js 92 bytes {0} [built]
    [5] ./~/core-js/library/fn/object/keys.js 102 bytes {0} [built]
    [6] ./~/core-js/library/modules/es6.object.keys.js 223 bytes {0} [built]
........
  [269] ./src ^\.\/(?!main(\.js)?$) 1.42 kB {0} [built]

WARNING in ./~/vue-loader/lib/template-compiler.js?{"id":"data-v-41f9ba10"}!./~/vue-loader/lib/selector.js?type=template&index=0!./test/components/IconToggle.vue
<mdl-icon-toggle v-for="label in 3">: component lists rendered with v-for should have explicit keys. See https://vuejs.org/guide/list.html#key for more info.

WARNING in ./~/vue-loader/lib/template-compiler.js?{"id":"data-v-9ae02164"}!./~/vue-loader/lib/selector.js?type=template&index=0!./test/components/Checkbox.vue
<mdl-checkbox v-for="label in 3">: component lists rendered with v-for should have explicit keys. See https://vuejs.org/guide/list.html#key for more info.

WARNING in ./~/vue-loader/lib/template-compiler.js?{"id":"data-v-f8352a02"}!./~/vue-loader/lib/template-loader.js?raw&engine=jade!./~/vue-loader/lib/selector.js?type=template&index=0!./test/components/Switch.vue
<mdl-switch v-for="label in 3">: component lists rendered with v-for should have explicit keys. See https://vuejs.org/guide/list.html#key for more info.

ERROR in ./~/vue-loader/lib/template-compiler.js?{"id":"data-v-1d1fe309"}!./~/vue-loader/lib/selector.js?type=template&index=0!./test/components/Tabs.vue

  Error compiling template:

  <div>
    <h1>Tabs</h1>

    <mdl-tabs :no-ripple-effect="!ripples" id="tabs" v-model="selected">
      <mdl-tab tab="Tab 1">
        Tab 1
      </mdl-tab>
      <mdl-tab tab="Tab 2">
        Tab 2
      </mdl-tab>
      <mdl-tab tab="Tab 3">
        Tab 3
      </mdl-tab>
      <mdl-tab
          v-for="(tab, index) in tabs"
          :key="index"
          :tab="tab"
      >
    </mdl-tabs>

    <mdl-tabs id="dyn-tabs" ref="tabs" v-model="selected">
      <mdl-tab
          v-for="(tab, index) in dynTabs"
          :key="index"
          :tab="{title: tab, id: index}"
      >
        {{tab}}
      </mdl-tab>
    </mdl-tabs>

    <br>
    <br>

    <button @click="addTab">Add Tab</button>
    <div v-for="(tab, index) in dynTabs" :key="index">
      <span>{{tab}}</span>
      <button @click="removeTab(index)">X</button>
    </div>
    <input type="checkbox" v-model="ripples"> Ripples
  </div>

  - tag <mdl-tab> has no matching end tag.

02 03 2017 14:17:36.615:WARN [karma]: No captured browser, open http://localhost:9876/
02 03 2017 14:17:36.946:INFO [karma]: Karma v1.5.0 server started at http://0.0.0.0:9876/
02 03 2017 14:17:36.947:INFO [launcher]: Launching browser PhantomJS with unlimited concurrency
02 03 2017 14:17:37.114:INFO [launcher]: Starting browser PhantomJS
02 03 2017 14:17:40.811:INFO [PhantomJS 2.1.1 (Windows 8 0.0.0)]: Connected on socket H_vON5eHkUYda4TJAAAA with id 3155993
INFO LOG: 'You are running Vue in development mode.
Make sure to turn on production mode when deploying for production.
See more tips at https://vuejs.org/guide/deployment.html'

  Badge
    √ exists
    √ is upgraded
    √ can have no background
    √ can overlap
    √ can hide the badge
    √ can hide badge with boolean

  Button
    √ exists
    √ is upgraded
    √ can be an anchor link
    √ can be colored
    √ can be raised
```