### PR TITLE
Fix warning message when run `npm run dev:integration`

### DIFF
--- a/test/components/Checkbox.vue
+++ b/test/components/Checkbox.vue
@@ -19,7 +19,7 @@
     <input id="classic" type="checkbox" v-model="check"/><span>Classic checkbox</span>
     <input id="disable" type="checkbox" v-model="disabled"/><span>Disable</span>
     <mdl-checkbox v-if="disabled" id="v-if" type="checkbox" v-model="check" :disabled="disabled">v-if</mdl-checkbox>
-    <mdl-checkbox v-for="(label, n) in 3" :val="indexId(n)" :id="indexId(n)" type="checkbox" v-model="checks">v-for {{indexId(n)}}</mdl-checkbox>
+    <mdl-checkbox v-for="(label, n) in 3" :val="indexId(n)" :id="indexId(n)" :key="indexId(n)" type="checkbox" v-model="checks">v-for {{indexId(n)}}</mdl-checkbox>
     <p id="checks">{{checks}}</p>
   </div>
 </template>

--- a/test/components/IconToggle.vue
+++ b/test/components/IconToggle.vue
@@ -19,7 +19,7 @@
     <input id="classic" type="checkbox" v-model="check"/><span>Classic icon-toggle</span>
     <input id="disable" type="checkbox" v-model="disabled"/><span>Disable</span>
     <mdl-icon-toggle v-if="disabled" icon="face" id="v-if" type="checkbox" v-model="check" :disabled="disabled"></mdl-icon-toggle>
-    <mdl-icon-toggle v-for="(label, n) in 3" icon="face" :val="indexId(n)" :id="indexId(n)" type="checkbox" v-model="checks"></mdl-icon-toggle>
+    <mdl-icon-toggle v-for="(label, n) in 3" icon="face" :val="indexId(n)" :id="indexId(n)" :key="indexId(n)" type="checkbox" v-model="checks"></mdl-icon-toggle>
     <p id="its">{{checks}}</p>
   </div>
 </template>

--- a/test/components/Switch.vue
+++ b/test/components/Switch.vue
@@ -18,7 +18,7 @@ div
     input#disable(type='checkbox' v-model='disabled')
     span Disable
   mdl-switch(v-if='disabled' id='v-if' type="checkbox" v-model='check' v-bind:disabled='disabled') v-if
-  mdl-switch(v-for='(label, n) in 3' v-bind:val='indexId(n)' v-bind:id='indexId(n)' type="checkbox" v-model='checks') v-for {{indexId(n)}}
+  mdl-switch(v-for='(label, n) in 3' v-bind:val='indexId(n)' v-bind:id='indexId(n)' v-bind:key="indexId(n)" type="checkbox" v-model='checks') v-for {{indexId(n)}}
   p#checks {{checks}}
 </template>
 


### PR DESCRIPTION
When i run `npm run dev:integration`, 3 warning on [key](https://vuejs.org/v2/guide/list.html#key) with use v-for:

```console
C:\Users\forresst\Lab\vue-mdl>npm run dev:integration

> vue-mdl@1.1.1 dev:integration C:\Users\forresst\Lab\vue-mdl
> cross-env NODE_ENV=dev node build/dev-server.js

Listening at http://localhost:8080

webpack built 3e3f3d82d2c4d9d37ec2 in 22868ms
Hash: 3e3f3d82d2c4d9d37ec2
Version: webpack 1.14.0
Time: 22868ms
     Asset       Size  Chunks             Chunk Names
    app.js    2.98 MB       0  [emitted]  app
index.html  575 bytes          [emitted]

WARNING in ./~/vue-loader/lib/template-compiler.js?{"id":"data-v-9ae02164"}!./~/vue-loader/lib/selector.js?type=template&index=0!./test/components/Checkbox.vue
<mdl-checkbox v-for="label in 3">: component lists rendered with v-for should have explicit keys. See https://vuejs.org/guide/list.html#key for more info.

WARNING in ./~/vue-loader/lib/template-compiler.js?{"id":"data-v-41f9ba10"}!./~/vue-loader/lib/selector.js?type=template&index=0!./test/components/IconToggle.vue
<mdl-icon-toggle v-for="label in 3">: component lists rendered with v-for should have explicit keys. See https://vuejs.org/guide/list.html#key for more info.

WARNING in ./~/vue-loader/lib/template-compiler.js?{"id":"data-v-f8352a02"}!./~/vue-loader/lib/template-loader.js?raw&engine=jade!./~/vue-loader/lib/selector.js?type=template&index=0!./test/components/Switch.vue
<mdl-switch v-for="label in 3">: component lists rendered with v-for should have explicit keys. See https://vuejs.org/guide/list.html#key for more info.
Child html-webpack-plugin for "index.html":
         Asset     Size  Chunks       Chunk Names
    index.html  22.4 kB       0
webpack: Compiled with warnings.
webpack: Compiling...
webpack building...
webpack built 29ba727648c0e69be36f in 1153ms
Hash: 29ba727648c0e69be36f
Version: webpack 1.14.0
Time: 1153ms
                               Asset      Size  Chunks             Chunk Names
                              app.js   2.98 MB       0  [emitted]  app
0.3e3f3d82d2c4d9d37ec2.hot-update.js   14.1 kB       0  [emitted]  app
3e3f3d82d2c4d9d37ec2.hot-update.json  36 bytes          [emitted]
```